### PR TITLE
helpers: update qa contact field id

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -57,7 +57,7 @@ type SecurityLevel struct {
 
 func GetIssueQaContact(issue *jira.Issue) (*jira.User, error) {
 	var obj *jira.User
-	isSet, err := GetUnknownField("customfield_12316243", issue, func() interface{} {
+	isSet, err := GetUnknownField("customfield_12315948", issue, func() interface{} {
 		obj = &jira.User{}
 		return obj
 	})


### PR DESCRIPTION
The name of the custom field for the QA contact changed. This PR updates
it.

/cc @bradmwilliams 