### PR TITLE
labels: add `bugzilla/valid-bug` label to valid bugs

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -569,7 +569,7 @@ Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jir
 				log.WithError(err).Error("Failed to add valid bugzilla bug label.")
 			}
 		}
-	} else if !needsValidLabel {
+	} else {
 		if hasValidJiraLabel {
 			if err := ghc.RemoveLabel(e.org, e.repo, e.number, labels.ValidBug); err != nil {
 				log.WithError(err).Error("Failed to remove valid bug label.")

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -209,7 +209,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityCritical}}}},
 			options:        JiraBranchOptions{}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug, labels.SeverityCritical},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityCritical},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -228,7 +228,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			name:           "invalid bug adds invalid label, removes valid label and comments",
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityImportant}}}},
 			options:        JiraBranchOptions{IsOpen: &open},
-			labels:         []string{labels.ValidBug, labels.SeverityCritical},
+			labels:         []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityCritical},
 			expectedLabels: []string{labels.InvalidBug, labels.SeverityImportant},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is invalid:
  - expected the bug to be open, but it isn't
@@ -250,8 +250,8 @@ Instructions for interacting with me using PR comments are available [here](http
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityImportant}}}},
 			options:        JiraBranchOptions{IsOpen: &open},
 			humanLabelled:  true,
-			labels:         []string{labels.ValidBug, labels.SeverityCritical},
-			expectedLabels: []string{labels.ValidBug, labels.SeverityImportant},
+			labels:         []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityCritical},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityImportant},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is invalid:
  - expected the bug to be open, but it isn't
 
@@ -272,7 +272,7 @@ Instructions for interacting with me using PR comments are available [here](http
 		{
 			name:    "no bug removes all labels and comments",
 			missing: true,
-			labels:  []string{labels.ValidBug, labels.InvalidBug},
+			labels:  []string{labels.ValidBug, labels.BugzillaValidBug, labels.InvalidBug},
 			expectedComment: `org/repo#1:@user: No Jira bug is referenced in the title of this pull request.
 To reference a bug, add 'OCPBUGS-XXX:' to the title of this pull request and request another bug refresh with <code>/jira refresh</code>.
 
@@ -300,7 +300,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}},
 			options:        JiraBranchOptions{StateAfterValidation: &updated}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug, labels.SeverityModerate},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityModerate},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the UPDATED state.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -324,7 +324,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityLow}}}},
 			options:        JiraBranchOptions{StateAfterValidation: &JiraBugState{Status: "CLOSED", Resolution: "VALIDATED"}}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug, labels.SeverityLow},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityLow},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the CLOSED (VALIDATED) state.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -355,7 +355,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{Status: &jira.Status{Name: "UPDATED"}}}},
 			options:        JiraBranchOptions{StateAfterValidation: &updated}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -376,7 +376,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			issues:         []jira.Issue{{ID: "1", Key: "OCPBUGS-123"}},
 			options:        JiraBranchOptions{AddExternalLink: &yes}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been updated to refer to the pull request using the external bug tracker.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -415,7 +415,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}},
 			options:        JiraBranchOptions{AddExternalLink: &yes}, // no requirements --> always valid
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -486,7 +486,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			existingIssueLinks: []*jira.IssueLink{&linkBetween123to124},
 			options:            JiraBranchOptions{IsOpen: &yes, TargetVersion: &v1Str, DependentBugStates: &verified, DependentBugTargetVersions: &[]string{v2Str}},
 			labels:             []string{labels.InvalidBug},
-			expectedLabels:     []string{labels.ValidBug},
+			expectedLabels:     []string{labels.ValidBug, labels.BugzillaValidBug},
 			expectedComment: `org/repo#2:@user: This pull request references [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124), which is valid.
 
 <details><summary>5 validation(s) were run on this bug</summary>
@@ -1269,7 +1269,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			prs:            []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}},
 			body:           "/jira refresh",
 			isComment:      true,
-			expectedLabels: []string{labels.ValidBug},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.
 
 <details><summary>No validations were run on this bug</summary></details>
@@ -1332,7 +1332,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}}}},
 			options:        JiraBranchOptions{StateAfterValidation: &updated, AllowedSecurityLevels: []string{"security"}},
 			labels:         []string{labels.InvalidBug},
-			expectedLabels: []string{labels.ValidBug, labels.SeverityModerate},
+			expectedLabels: []string{labels.ValidBug, labels.BugzillaValidBug, labels.SeverityModerate},
 			expectedComment: `org/repo#1:@user: This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid. The bug has been moved to the UPDATED state.
 
 <details><summary>No validations were run on this bug</summary></details>

--- a/pkg/labels/label.go
+++ b/pkg/labels/label.go
@@ -1,6 +1,7 @@
 package labels
 
 const (
+	BugzillaValidBug      = "bugzilla/valid-bug"
 	ValidBug              = "jira/valid-bug"
 	InvalidBug            = "jira/invalid-bug"
 	SeverityCritical      = "jira/severity-critical"


### PR DESCRIPTION
This PR changes functionality of the `jira-lifecycle-plugin` to add the
`bugzilla/valid-bug` label alongside the usual `jira/valid-bug` label to
workaround `tide` not supporting "or" statements for required labels.

/c @bradmwilliams 