### PR TITLE
server: require `OCPBUGS` dependent bugs

### DIFF
--- a/cmd/jira-lifecycle-plugin/config.go
+++ b/cmd/jira-lifecycle-plugin/config.go
@@ -44,6 +44,7 @@ type JiraBugState struct {
 //   - "status" if only resolution is empty
 //   - "any status with resolution RESOLUTION" if only status is empty
 //   - "" if both status and resolution are empty
+//
 // This is useful in user-facing messages that communicate bug state information
 func PrettyStatus(status, resolution string) string {
 	if resolution == "" {


### PR DESCRIPTION
This PR adds a validation check verifying that all dependent bugs are
part of the `OCPBUGS` project. If a dependent bug is not part of
`OCPBUGS`, the bot will also include instructions for backporting
Bugzilla bugs as part of its comment.