### PR TITLE
server: set issue type and affects version for new bugs

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1542,8 +1542,12 @@ func handleBZCherrypick(e event, gc githubClient, jc jiraclient.Client, bc bugzi
 		Project: jira.Project{
 			Key: "OCPBUGS",
 		},
-		Description: fmt.Sprintf("This bug is a backport clone of "+bzLink+". The following is the description of the original bug:\n---\n%s", parentBug.ID, bc.Endpoint(), parentBug.ID, comments[0].Text),
-		Summary:     parentBug.Summary,
+		Type: jira.IssueType{
+			Name: "Bug",
+		},
+		AffectsVersions: []*jira.AffectsVersion{{Name: targetVersion}},
+		Description:     fmt.Sprintf("This bug is a backport clone of "+bzLink+". The following is the description of the original bug:\n---\n%s", parentBug.ID, bc.Endpoint(), parentBug.ID, comments[0].Text),
+		Summary:         parentBug.Summary,
 		Unknowns: tcontainer.MarshalMap{
 			helpers.BlockedByBugzillaBug: fmt.Sprintf("%s/show_bug.cgi?id=%d", bc.Endpoint(), parentBZID),
 			helpers.TargetVersionField:   []*jira.Version{{Name: targetVersion}},

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -1503,7 +1503,11 @@ Instructions for interacting with me using PR comments are available [here](http
 				Project: jira.Project{
 					Key: "OCPBUGS",
 				},
-				Components: []*jira.Component{{Name: "Installer / openshift-ansible"}},
+				Type: jira.IssueType{
+					Name: "Bug",
+				},
+				AffectsVersions: []*jira.AffectsVersion{{Name: v1Str}},
+				Components:      []*jira.Component{{Name: "Installer / openshift-ansible"}},
 				Unknowns: tcontainer.MarshalMap{
 					helpers.TargetVersionField:   v1,
 					helpers.BlockedByBugzillaBug: "www.bugzilla/show_bug.cgi?id=1",
@@ -1563,7 +1567,11 @@ Instructions for interacting with me using PR comments are available [here](http
 				Project: jira.Project{
 					Key: "OCPBUGS",
 				},
-				Components: []*jira.Component{{Name: "Installer / openshift-ansible"}},
+				Type: jira.IssueType{
+					Name: "Bug",
+				},
+				AffectsVersions: []*jira.AffectsVersion{{Name: v1Str}},
+				Components:      []*jira.Component{{Name: "Installer / openshift-ansible"}},
 				Unknowns: tcontainer.MarshalMap{
 					helpers.TargetVersionField:   v1,
 					helpers.BlockedByBugzillaBug: "www.bugzilla/show_bug.cgi?id=1",


### PR DESCRIPTION
This PR adds the issue type and affects version fields to new bugs
created via the backport process, as these are required fields for new
bugs in OCPBUGS.