### PR TITLE
server: allow PR commit external link

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1373,7 +1373,7 @@ func handleMerge(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 			// this is not a github link
 			continue
 		}
-		if len(parts) != 4 && !(len(parts) == 5 && (parts[4] == "" || parts[4] == "files")) && !(len(parts) == 6 && (parts[4] == "files" && parts[5] == "")) {
+		if len(parts) != 4 && !(len(parts) == 5 && (parts[4] == "" || parts[4] == "files")) && !(len(parts) == 6 && ((parts[4] == "files" && parts[5] == "") || parts[4] == "commits")) {
 			log.WithError(err).Warn("Unexpected error splitting github URL for Jira external link.")
 			return comment(formatError(fmt.Sprintf("invalid pull identifier with %d parts: %q", len(parts), identifier), jc.JiraURL(), e.key, err))
 		}

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -631,8 +631,18 @@ Instructions for interacting with me using PR comments are available [here](http
 			}, {
 				ID: 2,
 				Object: &jira.RemoteLinkObject{
-					URL:   "https://github.com/org/repo/pull/22",
+					URL:   "https://github.com/org/repo/pull/22/commits/1234567890",
 					Title: "org/repo#22: OCPBUGS-123: fixed it!",
+					Icon: &jira.RemoteLinkIcon{
+						Url16x16: "https://github.com/favicon.ico",
+						Title:    "GitHub",
+					},
+				},
+			}, {
+				ID: 2,
+				Object: &jira.RemoteLinkObject{
+					URL:   "https://github.com/org/repo/pull/23/files",
+					Title: "org/repo#23: OCPBUGS-123: fixed it!",
 					Icon: &jira.RemoteLinkIcon{
 						Url16x16: "https://github.com/favicon.ico",
 						Title:    "GitHub",
@@ -640,11 +650,12 @@ Instructions for interacting with me using PR comments are available [here](http
 				},
 			},
 			}},
-			prs:     []github.PullRequest{{Number: base.number, Merged: true}, {Number: 22, Merged: true}},
+			prs:     []github.PullRequest{{Number: base.number, Merged: true}, {Number: 22, Merged: true}, {Number: 23, Merged: true}},
 			options: JiraBranchOptions{StateAfterMerge: &modified}, // no requirements --> always valid
 			expectedComment: `org/repo#1:@user: All pull requests linked via external trackers have merged:
  * [org/repo#1](https://github.com/org/repo/pull/1)
  * [org/repo#22](https://github.com/org/repo/pull/22)
+ * [org/repo#23](https://github.com/org/repo/pull/23)
 
 [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been moved to the MODIFIED state.
 


### PR DESCRIPTION
This adds support for processing links that referencing commits on a GitHub PR.