### PR TITLE
Enabling the processing of multi-line comments

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1102,7 +1102,7 @@ func digestComment(gc githubClient, log *logrus.Entry, ice github.IssueCommentEv
 			// this shouldn't be possible due to earlier cherrypick check
 			return nil, errors.New("failed to get cherrypick string match")
 		}
-		e.key = strings.TrimPrefix(mat[0], "/jira cherrypick ")
+		e.key = strings.TrimPrefix(strings.TrimRight(mat[0], "\r\n "), "/jira cherrypick ")
 		e.cherrypick = true
 		e.cherrypickCmd = true
 	}

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -2875,6 +2875,33 @@ Instructions for interacting with me using PR comments are available [here](http
 				org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-1234", body: "/jira cherrypick OCPBUGS-1234", htmlUrl: "www.com", login: "user", cherrypickCmd: true, missing: true, cherrypick: true,
 			},
 		},
+		{
+			name: "multiline cherrypick comment event",
+			e: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
+				Issue: github.Issue{
+					Number:      1,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/jira cherrypick OCPBUGS-1234\r\nThis is part of a\r\nmultiline comment",
+					User: github.User{
+						Login: "user",
+					},
+					HTMLURL: "www.com",
+				},
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "org",
+					},
+					Name: "repo",
+				},
+			},
+			title: "OCPBUGS-123: oopsie doopsie",
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 1, key: "OCPBUGS-1234", body: "/jira cherrypick OCPBUGS-1234\r\nThis is part of a\r\nmultiline comment", htmlUrl: "www.com", login: "user", cherrypickCmd: true, missing: false, cherrypick: true, isBug: true,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
If a user make a comment that has multiple lines, the plugin responds with an error:
https://github.com/openshift/cluster-image-registry-operator/pull/836#issuecomment-1413941431

GitHub's API returns the following:
```
"body": "/jira cherrypick OCPBUGS-6517\r\nTesting latest changes.  If successful, this new bug can be safely ignored and I will close it accordingly."
```

This is not necessarily the prettiest fix, but I couldnt get the regex to pick up the `\r`. 