### PR TITLE
Change `TargetVersion` verification to check for X.Y.*

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1416,9 +1416,19 @@ func validateTargetVersion(issue *jira.Issue, requiredTargetVersion string) erro
 	if len(targetVersion) > 1 {
 		return fmt.Errorf("expected the %s to target only the %q version, but multiple target versions were set", issueType, requiredTargetVersion)
 	}
-	prefixedRequiredTargetVersion := fmt.Sprintf("openshift-%s", requiredTargetVersion)
-	if requiredTargetVersion != targetVersion[0].Name && prefixedRequiredTargetVersion != targetVersion[0].Name {
-		return fmt.Errorf("expected the %s to target either version %q or %q, but it targets %q instead", issueType, requiredTargetVersion, prefixedRequiredTargetVersion, targetVersion[0].Name)
+	//prefixedRequiredTargetVersion := fmt.Sprintf("openshift-%s", requiredTargetVersion)
+	//if requiredTargetVersion != targetVersion[0].Name && prefixedRequiredTargetVersion != targetVersion[0].Name {
+	//	return fmt.Errorf("expected the %s to target either version %q or %q, but it targets %q instead", issueType, requiredTargetVersion, prefixedRequiredTargetVersion, targetVersion[0].Name)
+	//}
+	// TODO: Remove this truncated version check...
+	truncatedRequiredTargetVersion := requiredTargetVersion
+	pieces := strings.Split(requiredTargetVersion, ".")
+	if len(pieces) >= 2 {
+		truncatedRequiredTargetVersion = fmt.Sprintf("%s.%s", pieces[0], pieces[1])
+	}
+	truncatedPrefixedRequiredTargetVersion := fmt.Sprintf("openshift-%s", truncatedRequiredTargetVersion)
+	if !strings.HasPrefix(targetVersion[0].Name, truncatedRequiredTargetVersion) && !strings.HasPrefix(targetVersion[0].Name, truncatedPrefixedRequiredTargetVersion) {
+		return fmt.Errorf("expected the %s to target either version %q or %q, but it targets %q instead", issueType, fmt.Sprintf("%s.*", truncatedRequiredTargetVersion), fmt.Sprintf("%s.*", truncatedPrefixedRequiredTargetVersion), targetVersion[0].Name)
 	}
 	return nil
 }

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -4258,7 +4258,7 @@ func TestValidateBug(t *testing.T) {
 			}},
 			options: JiraBranchOptions{TargetVersion: &oneStr},
 			valid:   false,
-			why:     []string{"expected the bug to target either version \"v1\" or \"openshift-v1\", but it targets \"v2\" instead"},
+			why:     []string{"expected the bug to target either version \"v1.*\" or \"openshift-v1.*\", but it targets \"v2\" instead"},
 		},
 		{
 			name: "not setting target version requirement means an invalid bug",
@@ -4367,7 +4367,7 @@ func TestValidateBug(t *testing.T) {
 			valid:       false,
 			validations: []string{"bug has dependents"},
 			why: []string{"expected the bug to be open, but it isn't",
-				"expected the bug to target either version \"v2\" or \"openshift-v2\", but it targets \"v1\" instead",
+				"expected the bug to target either version \"v2.*\" or \"openshift-v2.*\", but it targets \"v1\" instead",
 				"expected the bug to be in one of the following states: VERIFIED, but it is CLOSED instead",
 				"expected dependent [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124) to be in one of the following states: VERIFIED, but it is MODIFIED instead",
 			},


### PR DESCRIPTION
In response to:

> can we change the logic to tolerate jiras that target openshift-4.15* (and 4.15*) instead of requiring openshift-4.15.0 (and 4.15.0)?

This PR changes the logic to check for `TargetVersions` that are not prefixed with a matching `Major.Minor` or `openshift-Major.Minor` version.
