### PR TITLE
server,config: add release notes requirement options

### DIFF
--- a/cmd/jira-lifecycle-plugin/config_test.go
+++ b/cmd/jira-lifecycle-plugin/config_test.go
@@ -113,6 +113,18 @@ func TestResolveJiraOptions(t *testing.T) {
 			expected: JiraBranchOptions{IsOpen: &closed, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
 		},
 		{
+			name:     "child overrides parent on RequireReleaseNotes",
+			parent:   JiraBranchOptions{RequireReleaseNotes: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{RequireReleaseNotes: &closed},
+			expected: JiraBranchOptions{RequireReleaseNotes: &closed, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+		},
+		{
+			name:     "child overrides parent on ReleaseNotesDefaultText",
+			parent:   JiraBranchOptions{ReleaseNotesDefaultText: &one, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+			child:    JiraBranchOptions{ReleaseNotesDefaultText: &two},
+			expected: JiraBranchOptions{ReleaseNotesDefaultText: &two, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
+		},
+		{
 			name:     "child overrides parent on target release",
 			parent:   JiraBranchOptions{IsOpen: &open, TargetVersion: &one, ValidStates: &[]JiraBugState{modifiedState}, StateAfterValidation: &postState},
 			child:    JiraBranchOptions{TargetVersion: &two},

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1333,6 +1333,21 @@ func validateBug(bug *jira.Issue, dependents []dependent, options JiraBranchOpti
 		}
 	}
 
+	if options.RequireReleaseNotes != nil && *options.RequireReleaseNotes {
+		releaseNotes, err := helpers.GetIssueReleaseNotesText(bug)
+		if err != nil {
+			errors = append(errors, err.Error())
+			valid = false
+		} else {
+			if releaseNotes == nil || *releaseNotes == "" || (options.ReleaseNotesDefaultText != nil && *options.ReleaseNotesDefaultText == *releaseNotes) {
+				valid = false
+				errors = append(errors, "release notes must be set and not match default text")
+			} else {
+				validations = append(validations, "release notes are set")
+			}
+		}
+	}
+
 	if options.DependentBugStates != nil {
 		for _, bug := range dependents {
 			if !strings.HasPrefix(bug.key, "OCPBUGS-") {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -13,6 +13,7 @@ const (
 	TargetVersionFieldOld = "customfield_12319940"
 	TargetVersionField    = "customfield_12323140"
 	ReleaseBlockerField   = "customfield_12319743"
+	ReleaseNotesTextField = "customfield_12317313"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
@@ -111,4 +112,17 @@ type CustomField struct {
 	ID       string `json:"id"`
 	Value    string `json:"value"`
 	Disabled bool   `json:"disabled"`
+}
+
+func GetIssueReleaseNotesText(issue *jira.Issue) (*string, error) {
+	var obj *string
+	isSet, err := GetUnknownField(ReleaseNotesTextField, issue, func() interface{} {
+		var field string
+		obj = &field
+		return obj
+	})
+	if !isSet {
+		return nil, err
+	}
+	return obj, err
 }


### PR DESCRIPTION
This PR adds 2 config options to configure release notes requirements for jira bugs.