### PR TITLE
OCPCRT-259: server,helpers: add support for update assignee and Sprint during clone

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1762,10 +1762,14 @@ refBugLoop:
 		update := jira.Issue{
 			Key: clone.Key,
 			Fields: &jira.IssueFields{
+				Assignee: bug.Fields.Assignee,
 				Unknowns: tcontainer.MarshalMap{
 					helpers.TargetVersionField: []*jira.Version{{Name: targetVersion}},
 				},
 			},
+		}
+		if sprint := helpers.GetSprintField(bug); sprint != nil {
+			update.Fields.Unknowns[helpers.SprintField] = sprint
 		}
 		_, err = jc.UpdateIssue(&update)
 		if err != nil {

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -1825,7 +1825,8 @@ Instructions for interacting with me using PR comments are available [here](http
 		{
 			name: "Cherrypick PR results in cloned bug creation",
 			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
-				Status: &jira.Status{Name: "CLOSED"},
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
 				Comments: &jira.Comments{Comments: []*jira.Comment{{
 					Body: "This is a bug",
 				}}},
@@ -1856,6 +1857,7 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 			expectedIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
 				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Assignee:    &jira.User{Name: "testUser"},
 				Status:      &jira.Status{Name: "CLOSED"},
 				Comments: &jira.Comments{Comments: []*jira.Comment{{
 					Body: "This is a bug",
@@ -1867,6 +1869,59 @@ Instructions for interacting with me using PR comments are available [here](http
 				Unknowns: tcontainer.MarshalMap{
 					helpers.SeverityField:      map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
 					helpers.TargetVersionField: []interface{}{map[string]interface{}{"name": v1Str}},
+				},
+			}},
+		},
+		{
+
+			name: "Cherrypick PR with Sprint field results in cloned bug creation",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+				},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+					helpers.SprintField:        severityLow, // the sprint field is just an interface{}, so any pointer value can be used
+				},
+			}}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherrypick:          true,
+			cherryPickFromPRNum: 1,
+			options:             JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124). Will retitle bug to link to clone.
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedIssue: &jira.Issue{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Assignee:    &jira.User{Name: "testUser"},
+				Status:      &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+				},
+				IssueLinks: []*jira.IssueLink{&cloneLinkTo123JustID, &blocksLinkTo123JustID},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					helpers.TargetVersionField: []interface{}{map[string]interface{}{"name": v1Str}},
+					helpers.SprintField:        map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/low.svg" width="16" height="16"> Low`},
 				},
 			}},
 		},

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -14,6 +14,7 @@ const (
 	TargetVersionFieldOld = "customfield_12323140"
 	ReleaseBlockerField   = "customfield_12319743"
 	ReleaseNotesTextField = "customfield_12317313"
+	SprintField           = "customfield_12310940"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
@@ -36,7 +37,19 @@ func GetUnknownField(field string, issue *jira.Issue, fn func() interface{}) (bo
 		return true, fmt.Errorf("failed to unmarshal the json to struct for %s. Error: %v", field, err)
 	}
 	return true, nil
+}
 
+// GetSprintField returns a raw interface for the Sprint value of an issue if it exists. Currently, the value
+// is only used during cloning, so no struct is currently needed for us to parse data from the interface.
+func GetSprintField(issue *jira.Issue) interface{} {
+	if issue.Fields == nil || issue.Fields.Unknowns == nil {
+		return nil
+	}
+	sprintObject, ok := issue.Fields.Unknowns[SprintField]
+	if !ok {
+		return nil
+	}
+	return sprintObject
 }
 
 // GetIssueSecurityLevel returns the security level of an issue. If no security level


### PR DESCRIPTION
This PR adds the `Assignee` as one of the values that gets updated after bug creation during the cherrypick cloning process. It also adds basic support for cloning the `Sprint` value during the post-clone update, but does not add the struct as the plugin does not need to parse any data from it. While `OCPBUGS` does not use the `Sprint` field, other projects do and while the plugin does not fully support non-OCPBUGS projects, this did not require too much extra effort to implement.