### PR TITLE
server: fix USHIFT cloning

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1734,6 +1734,14 @@ refBugLoop:
 				continue refBugLoop
 			}
 		}
+		// TODO: these fields can cause the clone to fail if not manually removed. It may be better to
+		// perform some recursion when cloning issues, as these only error when everything else is correct...
+		delete(bug.Fields.Unknowns, "environment")
+		delete(bug.Fields.Unknowns, "customfield_12318341")
+		// This is the sprint field; sprints are handled by a custom plugin, and the data given to us via
+		// GetIssue is invalid on Create or Update.
+		// TODO: investigate how to handle the Sprint field
+		delete(bug.Fields.Unknowns, "customfield_12310940")
 		clone, err := jc.CloneIssue(bug)
 		if err != nil {
 			log.WithError(err).Debugf("Failed to clone bug %+v", bugs)
@@ -1768,9 +1776,12 @@ refBugLoop:
 				},
 			},
 		}
-		if sprint := helpers.GetSprintField(bug); sprint != nil {
-			update.Fields.Unknowns[helpers.SprintField] = sprint
-		}
+		// TODO: investigate how to handle the Sprint field
+		/*
+			if sprint := helpers.GetSprintField(bug); sprint != nil {
+				update.Fields.Unknowns[helpers.SprintField] = sprint
+			}
+		*/
 		_, err = jc.UpdateIssue(&update)
 		if err != nil {
 			response += fmt.Sprintf(`

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -1921,7 +1921,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				Unknowns: tcontainer.MarshalMap{
 					helpers.SeverityField:      map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
 					helpers.TargetVersionField: []interface{}{map[string]interface{}{"name": v1Str}},
-					helpers.SprintField:        map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/low.svg" width="16" height="16"> Low`},
+					//helpers.SprintField:        map[string]interface{}{"Value": `<img alt="" src="/images/icons/priorities/low.svg" width="16" height="16"> Low`},
 				},
 			}},
 		},


### PR DESCRIPTION
This PR has a workaround for broken USHIFT cloning. It also temporarily disables setting of the Sprint field, as that breaks the update function.