### PR TITLE
server: add Release Note Type check

### DIFF
--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -4408,30 +4408,37 @@ func TestValidateBug(t *testing.T) {
 			name: "matching release notes requirement means a valid bug",
 			issue: &jira.Issue{Fields: &jira.IssueFields{
 				Unknowns: tcontainer.MarshalMap{
-					helpers.ReleaseNotesTextField: "These are release notes",
+					helpers.ReleaseNoteTextField: "These are release notes",
 				},
 			}},
 			options:     JiraBranchOptions{RequireReleaseNotes: &yes, ReleaseNotesDefaultText: &oneStr},
 			valid:       true,
-			validations: []string{"release note type is set and release note text does not match the template"},
+			validations: []string{"release note text is set and does not match the template"},
 		},
 		{
 			name:    "no release notes with release notes requirement means an invalid bug",
 			issue:   &jira.Issue{Fields: &jira.IssueFields{}},
 			options: JiraBranchOptions{RequireReleaseNotes: &yes, ReleaseNotesDefaultText: &oneStr},
 			valid:   false,
-			why:     []string{"release note type must be set and release note text must not match the template"},
+			why:     []string{"release note text must be set and not match the template OR release note type must be set to \"Release Note Not Required\""},
 		},
 		{
 			name: "release notes matching default text means an invalid bug",
 			issue: &jira.Issue{Fields: &jira.IssueFields{
 				Unknowns: tcontainer.MarshalMap{
-					helpers.ReleaseNotesTextField: oneStr,
+					helpers.ReleaseNoteTextField: oneStr,
 				},
 			}},
 			options: JiraBranchOptions{RequireReleaseNotes: &yes, ReleaseNotesDefaultText: &oneStr},
 			valid:   false,
-			why:     []string{"release note type must be set and release note text must not match the template"},
+			why:     []string{"release note text must be set and not match the template OR release note type must be set to \"Release Note Not Required\""},
+		},
+		{
+			name:        "no release notes with release notes requirement but release type set to not required means an valid bug",
+			issue:       &jira.Issue{Fields: &jira.IssueFields{Unknowns: tcontainer.MarshalMap{helpers.ReleaseNoteTypeField: helpers.CustomField{Value: "Release Note Not Required"}}}},
+			options:     JiraBranchOptions{RequireReleaseNotes: &yes, ReleaseNotesDefaultText: &oneStr},
+			valid:       true,
+			validations: []string{"release note type set to \"Release Note Not Required\""},
 		},
 		{
 			name: "matching target version requirement means a valid bug",

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -16,8 +16,9 @@ const (
 	TargetVersionField    = "customfield_12319940"
 	TargetVersionFieldOld = "customfield_12323140"
 	ReleaseBlockerField   = "customfield_12319743"
-	ReleaseNotesTextField = "customfield_12317313"
+	ReleaseNoteTextField  = "customfield_12317313"
 	SprintField           = "customfield_12310940"
+	ReleaseNoteTypeField  = "customfield_12320850"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
@@ -130,11 +131,23 @@ type CustomField struct {
 	Disabled bool   `json:"disabled"`
 }
 
-func GetIssueReleaseNotesText(issue *jira.Issue) (*string, error) {
+func GetIssueReleaseNoteText(issue *jira.Issue) (*string, error) {
 	var obj *string
-	isSet, err := GetUnknownField(ReleaseNotesTextField, issue, func() interface{} {
+	isSet, err := GetUnknownField(ReleaseNoteTextField, issue, func() interface{} {
 		var field string
 		obj = &field
+		return obj
+	})
+	if !isSet {
+		return nil, err
+	}
+	return obj, err
+}
+
+func GetIssueReleaseNoteType(issue *jira.Issue) (*CustomField, error) {
+	var obj *CustomField
+	isSet, err := GetUnknownField(ReleaseNoteTypeField, issue, func() interface{} {
+		obj = &CustomField{}
 		return obj
 	})
 	if !isSet {


### PR DESCRIPTION
This adds a check to allow `Release Note Not Needed` set as the Release Note Type to override the release notes text requirement. This also changes the release note variables and functions to better match the jira fields.