### PR TITLE
.devcontainer: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay-proxy.ci.openshift.org/openshift/ci:openshift_release_rhel-9-release-golang-1.22-openshift-4.17
+# Create non-root user for rootless podman installations
+RUN groupadd --gid 1000 dev && useradd --uid 1000 --gid 1000 -m dev && mkdir /home/dev/go && chown -R dev:dev /home/dev/go
+USER dev
+# Use home go directories instead of /go and disable GOFLAGS='' to prevent issue caused by forcing -mod=vendor
+ENV GOPATH=/home/dev/go GOCACHE=/home/dev/go/cache GOFLAGS='' PATH=/home/dev/go/bin:${PATH} GOVERSION=v0.0.0
+# Install common golang tools
+RUN echo $PATH && go install golang.org/x/vuln/cmd/govulncheck@latest && \
+    go install golang.org/x/tools/gopls@latest && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "RHEL Go",
+	"build": { "dockerfile": "Dockerfile" },
+
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": ["golang.go", "ms-azuretools.vscode-docker"]
+		}
+	},
+
+	// The following allow us to use rootless podman
+	"runArgs": [
+		"--userns=keep-id:uid=1000,gid=1000"
+	],
+	"containerUser": "dev",
+	"updateRemoteUserUID": true,
+	"containerEnv": {
+		"HOME": "/home/dev"
+	}
+}


### PR DESCRIPTION
This PR adds an initial devcontainer json and Containerfile that uses the openshift-4.17 golang-1.22 builder image, makes adjustments to allow it to run in rootless podman, and installs commonly used golang tools. It also configures the vscode to enable the go and docker extensions in the devcontainer. Note that users will need to be logged into the quay-proxy registry to pull the base image for the Containerfile.