### PR TITLE
Processing `Restricted` Jira Issues

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -19,6 +19,7 @@ const (
 	ReleaseNoteTextField  = "customfield_12317313"
 	SprintField           = "customfield_12310940"
 	ReleaseNoteTypeField  = "customfield_12320850"
+	ContributorsField     = "customfield_12319640"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal
@@ -181,4 +182,21 @@ func GetActiveSprintID(sprintField interface{}) (int, error) {
 		}
 	}
 	return -1, nil
+}
+
+type Contributor struct {
+	Self string `json:"self"`
+	Name string `json:"name"`
+}
+
+func GetIssueContributors(issue *jira.Issue) (*[]Contributor, error) {
+	var obj *[]Contributor
+	isSet, err := GetUnknownField(ContributorsField, issue, func() interface{} {
+		obj = &[]Contributor{}
+		return obj
+	})
+	if !isSet {
+		return nil, err
+	}
+	return obj, err
 }


### PR DESCRIPTION
This is a special case, for RedHat, to handle the cases if/when a Jira issue has been marked "Restricted" to allow for contributors from "other" locations the ability to cherrypick PR's associated to the corresponding Ticket.

This PR add a check to verify that `Red Hat Employee` is both:
1. an allowed security level
2. a member of the Contributors group

If both of these conditions are true, we'll allow further processing of the issue.
If not, no further processing will occur.