### PR TITLE
server: don't split target version for DFBUGS project

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1550,7 +1550,7 @@ func validateTargetVersion(issue *jira.Issue, requiredTargetVersion string) erro
 	// TODO: Remove this truncated version check...
 	truncatedRequiredTargetVersion := requiredTargetVersion
 	pieces := strings.Split(requiredTargetVersion, ".")
-	if len(pieces) >= 2 {
+	if issue.Fields.Project.Key != "DFBUGS" && len(pieces) >= 2 {
 		truncatedRequiredTargetVersion = fmt.Sprintf("%s.%s", pieces[0], pieces[1])
 	}
 	truncatedPrefixedRequiredTargetVersion := fmt.Sprintf("openshift-%s", truncatedRequiredTargetVersion)


### PR DESCRIPTION
don't split and compare target version value for DFBUGS project, because we need to validate the z-stream versions for each issues and then plan if the issue can be considered for the respective z-stream release.
Ref: https://github.com/red-hat-storage/odf-operator/pull/421#issuecomment-2597585141