### PR TITLE
Protect the bigqueryInserter initialization

### DIFF
--- a/cmd/jira-lifecycle-plugin/main.go
+++ b/cmd/jira-lifecycle-plugin/main.go
@@ -206,6 +206,13 @@ func main() {
 		}
 	}
 
+	var bigqueryInserter BigQueryInserter
+	if bigqueryClient != nil {
+		bigqueryInserter = bigqueryClient.Dataset(o.bigqueryDatasetID).Table(bigqueryTableName).Inserter()
+	} else {
+		bigqueryInserter = &fakeBigQueryInserter{}
+	}
+
 	serv := &server{
 		config: func() *Config {
 			o.mut.Lock()
@@ -216,7 +223,7 @@ func main() {
 		jc:              jiraClient.WithFields(logger.Data).ForPlugin(PluginName),
 		prowConfigAgent: configAgent,
 
-		bigqueryInserter: bigqueryClient.Dataset(o.bigqueryDatasetID).Table(bigqueryTableName).Inserter(),
+		bigqueryInserter: bigqueryInserter,
 	}
 
 	eventServer := githubeventserver.New(o.githubEventServerOptions, secret.GetTokenGenerator(o.webhookSecretFile), logger)


### PR DESCRIPTION
Observed a panic this morning:
```
$ app -n ci logs jira-lifecycle-plugin-5c5c9b667d-dtcnn
{"client":"github","component":"jira-lifecycle-plugin","file":"sigs.k8s.io/prow@v0.0.0-20250205101216-e871edfd1e0c/pkg/github/client.go:801","func":"sigs.k8s.io/prow/pkg/github.(*client).log","level":"info","msg":"Throttle(0, 0, [])","severity":"info","time":"2025-06-06T12:56:57Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x233ae50]

goroutine 1 [running]:
cloud.google.com/go/bigquery.(*Client).Dataset(...)
	cloud.google.com/go/bigquery@v1.62.0/dataset.go:162
main.main()
	github.com/openshift-eng/jira-lifecycle-plugin/cmd/jira-lifecycle-plugin/main.go:219 +0xcf0
```