### PR TITLE
server: add verification removal functionality

### DIFF
--- a/cmd/jira-lifecycle-plugin/bigquery.go
+++ b/cmd/jira-lifecycle-plugin/bigquery.go
@@ -8,9 +8,13 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
-const bigqueryTableName = "verified"
-const verifyMergeType = "merge"
-const verifyLaterType = "later"
+const (
+	bigqueryTableName     = "verified"
+	verifyMergeType       = "merge"
+	verifyLaterType       = "later"
+	verifyRemoveType      = "remove"
+	verifyRemoveLaterType = "removeLater"
+)
 
 type BigQueryInserter interface {
 	Put(ctx context.Context, src any) (err error)


### PR DESCRIPTION
Add the ability to remove the verified labels via a `/verified later` command and automatically remove the verified labels if a PR's contents are modified.