### PR TITLE
Reworking the /verified logic

### DIFF
--- a/cmd/jira-lifecycle-plugin/bigquery.go
+++ b/cmd/jira-lifecycle-plugin/bigquery.go
@@ -14,6 +14,7 @@ const (
 	verifyLaterType       = "later"
 	verifyRemoveType      = "remove"
 	verifyRemoveLaterType = "removeLater"
+	verifyBypassType      = "bypass"
 )
 
 type BigQueryInserter interface {

--- a/cmd/jira-lifecycle-plugin/config_test.go
+++ b/cmd/jira-lifecycle-plugin/config_test.go
@@ -657,3 +657,55 @@ func TestJiraStatesMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestPreMergeVerificationOptionsExcluded(t *testing.T) {
+	testCases := []struct {
+		name      string
+		options   PreMergeVerificationOptions
+		org, repo string
+		expected  bool
+	}{
+		{
+			name:     "nil options",
+			options:  PreMergeVerificationOptions{},
+			org:      "org1",
+			repo:     "repo1",
+			expected: false,
+		},
+		{
+			name: "no match",
+			options: PreMergeVerificationOptions{
+				ExcludedRepositories: []string{
+					"org1/repo1",
+					"org2/repo2",
+					"org3/repo3",
+				},
+			},
+			org:      "org4",
+			repo:     "repo4",
+			expected: false,
+		},
+		{
+			name: "match",
+			options: PreMergeVerificationOptions{
+				ExcludedRepositories: []string{
+					"org1/repo1",
+					"org2/repo2",
+					"org3/repo3",
+				},
+			},
+			org:      "org2",
+			repo:     "repo2",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.options.Excluded(tc.org, tc.repo)
+			if actual != tc.expected {
+				t.Errorf("%s: expected %t, got %t", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR re-works the logic for the `/verified` commands.  Generally, the process should work like this:

Moving forward the `verified` label is going to be required to merge PRs for everything under the `openshift` organization.  To obtain the label, one of the following commands must be issued:
1. `/verified by`
  This is the preferred method and means that the PR has been pre-merge verified by the specified user/test
2. `/verified later`
  This command means that the PR will require post-merge verification if/when the PR is included into an `Accepted` nightly release
3. `/verified bypass`
  For any PRs that require the label, but do not require pre/post-merge verification to occur.  The expectation is that this command will be used sparingly. 

At any time, pre-merge, the `verified` label can be removed via the `/verified remove` command.

All `/verified` operations will be logged as one or more entries in BigQuery.  The inserts will track the root cause ( like a comment) and the respective actions taken (adding/removing the appropriate labels). 

This PR introduces a couple new features:
1. The `/verified bypass` logic
2. A `premerge_verification` configuration stanza to specify non-product repositories that will **NOT** have their associated Jira tickets moved to the `VERIFIED` state if/when the PR is included into an `Accepted` nightly release.  When PRs in these repositories merge, the `jira-lifecycle-plugin` will be responsible for moving the associated jira tickets into the `VERIFIED` state
  A sample of the configuration looks like this:
  ```
  premerge_verification:
    excluded_repositories:
    - openshift/ansible-operator-plugins
    - openshift/aws-efs-csi-driver
    - openshift/aws-efs-utils
    - openshift/azure-storage-azcopy
    - openshift/cluster-capacity
    - openshift/cluster-nfd-operator
    - openshift/cluster-resource-override-admission
  ```