### PR TITLE
Bumping up to GoLang 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@ build_root_image:
   use_build_cache: true
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.21


### PR DESCRIPTION
The release-controller and ci-chat-bot were bumped last week.  Just following suite