### PR TITLE
NO-ISSUE: feat(config): allow configuring bug projects for lifecycle management

### DIFF
--- a/cmd/jira-lifecycle-plugin/config.go
+++ b/cmd/jira-lifecycle-plugin/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	Orgs map[string]JiraOrgOptions `json:"orgs,omitempty"`
 	// PreMergeVerification options for Pre-Merge Verification.
 	PreMergeVerification PreMergeVerificationOptions `json:"premerge_verification,omitempty"`
+	// BugProjects is a list of Jira project keys that should be treated as bug projects,
+	// enabling full lifecycle management (validation, state transitions, severity labels,
+	// cherry-picks, backports). If not set, defaults to OCPBUGS and DFBUGS.
+	BugProjects []string `json:"bug_projects,omitempty"`
 }
 
 // JiraOrgOptions holds options for checking Jira bugs for an org.
@@ -443,6 +447,15 @@ type PreMergeVerificationOptions struct {
 
 func (b *Config) OptionsForPreMergeVerification() PreMergeVerificationOptions {
 	return b.PreMergeVerification
+}
+
+// GetBugProjects returns the set of Jira project keys that should be treated as
+// bug projects. If not configured, defaults to OCPBUGS and DFBUGS.
+func (c *Config) GetBugProjects() sets.Set[string] {
+	if len(c.BugProjects) > 0 {
+		return sets.New(c.BugProjects...)
+	}
+	return bugProjects
 }
 
 // Excluded checks whether the specified repository is excluded from pre-merge validation

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -379,7 +379,11 @@ func (s *server) handleIssueComments(l *logrus.Entry, e github.IssueCommentEvent
 	for _, err := range errs {
 		l.Errorf("failed to digest comment: %v", err)
 	}
+	configuredBugProjects := cfg.GetBugProjects()
 	for _, event := range events {
+		for i := range event.issues {
+			event.issues[i].IsBug = configuredBugProjects.Has(event.issues[i].Project)
+		}
 		branchOptions := cfg.OptionsForBranch(event.org, event.repo, event.baseRef)
 		repoOptions := cfg.OptionsForRepo(event.org, event.repo)
 		verificationOptions := cfg.OptionsForPreMergeVerification()
@@ -1104,6 +1108,10 @@ func (s *server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 		l.Errorf("failed to digest PR: %v", err)
 	}
 	if event != nil {
+		configuredBugProjects := cfg.GetBugProjects()
+		for i := range event.issues {
+			event.issues[i].IsBug = configuredBugProjects.Has(event.issues[i].Project)
+		}
 		repoOptions := cfg.OptionsForRepo(event.org, event.repo)
 		if err := handle(s.jc, s.ghc, s.bigqueryInserter, repoOptions, branchOptions, verificationOptions, l, *event, s.prowConfigAgent.Config().AllRepos); err != nil {
 			l.Errorf("failed to handle PR: %v", err)
@@ -1517,7 +1525,7 @@ func getSeverityLabel(severity string) string {
 	case informationalSeverity:
 		return labels.SeverityInformational
 	}
-	//If we don't understand the severity, don't set it but don't error.
+	// If we don't understand the severity, don't set it but don't error.
 	return ""
 }
 
@@ -2856,7 +2864,6 @@ func getVerifiedLaterMessage(e event, verificationOptions PreMergeVerificationOp
 }
 
 func notifyQAContact(jc jiraclient.Client, ghc githubClient, log *logrus.Entry, issue *jira.Issue, refIssue referencedIssue, comment func(string) error, e event, response string) (string, error) {
-
 	qaContactDetail, err := helpers.GetIssueQaContact(issue)
 	if err != nil {
 		return "", comment(formatError("processing qa contact information", jc.JiraURL(), refIssue.Key(), err))


### PR DESCRIPTION
Add `bug_projects` config field so projects like PROJQUAY can get
full bug lifecycle handling without code changes.

Need to follow up setting `bug_projects` in openshift/release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable bug projects setting, allowing administrators to specify which Jira projects should be treated as bug projects in the plugin configuration.

* **Improvements**
  * Enhanced bug issue classification to dynamically determine whether issues are bugs based on the configured project list, improving accuracy in bug tracking and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->