### PR TITLE
NO-ISSUE: fix(cmd): no attachments when cloning

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2187,6 +2187,8 @@ func createCherryPickBug(jc jcWithGetUser, bug *jira.Issue, branch string, optio
 	delete(bugCopy.Fields.Unknowns, helpers.RankField)
 	delete(bugCopy.Fields.Unknowns, helpers.DateOfFirstResponseField)
 	delete(bugCopy.Fields.Unknowns, helpers.TimeInStatusField)
+	// Attachments cannot be set via the Create Issue API; they must be uploaded separately
+	bugCopy.Fields.Attachments = nil
 	// This is the sprint field; sprints are handled by a custom plugin, and the data given to us via
 	// GetIssue is invalid for setting the field ourselves
 	sprintField := bugCopy.Fields.Unknowns[helpers.SprintField]


### PR DESCRIPTION
We hit an issue on our first JIRA issue clone due to attachments. Taking
a quick look it seems OCPBUGS doesn't have attachments enabled? We make
heavy use of them in PROJQUAY leading to this error:

```
request failed. Please analyze the request body for more details. Status code: 400: {"errorMessages":[],"errors":{"attachment":"string expected at index 0"}}
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>

https://github.com/quay/quay/pull/5632#issuecomment-4166327919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where attachments were incorrectly included when cloning Jira issues, preventing failures during the cherry-pick bug creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->