### PR TITLE
feat(cmd): support jlp-no-clone label to skip cherry-pick cloning

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2098,7 +2098,9 @@ func handleCherrypick(e event, gc githubClient, jc jcWithGetUser, options JiraBr
 			}
 		}
 		cloneKey, response, err := createCherryPickBug(jc, bug, e.baseRef, options, log)
-		retitleList[refIssue.Key()] = cloneKey
+		if cloneKey != "" {
+			retitleList[refIssue.Key()] = cloneKey
+		}
 		msg += response
 		if err != nil {
 			msg += err.Error()
@@ -2146,6 +2148,9 @@ func createCherryPickBug(jc jcWithGetUser, bug *jira.Issue, branch string, optio
 		return "", "", nil
 	}
 	oldLink := fmt.Sprintf(issueLink, bug.Key, jc.JiraURL(), bug.Key)
+	if slices.Contains(bug.Fields.Labels, "jlp-no-clone") {
+		return "", fmt.Sprintf("The bug %s has the `jlp-no-clone` label, skipping clone creation.", oldLink), nil
+	}
 	for _, label := range bug.Fields.Labels {
 		match := existingBackportMatch.FindString(label)
 		if len(match) > 0 {
@@ -2402,9 +2407,13 @@ func createLinkedJiras(jc jcWithGetUser, parentIssue *jira.Issue, parentBranch s
 	children := []*jira.Issue{}
 	log.Infof("Starting childBranch loop")
 	for _, childBranch := range childBranches[parentBranch] {
-		cloneKey, _, err := createCherryPickBug(jc, parentIssue, childBranch, repoOptions[childBranch], log)
+		cloneKey, msg, err := createCherryPickBug(jc, parentIssue, childBranch, repoOptions[childBranch], log)
 		if err != nil {
 			return nil, err
+		}
+		if cloneKey == "" {
+			log.Info(msg)
+			continue
 		}
 		log.Infof("Cloned %s as %s", parentIssue.Key, cloneKey)
 		createdIssues[cloneKey] = childBranch

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -2672,6 +2672,78 @@ Instructions for interacting with me using PR comments are available [here](http
 			}}},
 		},
 		{
+			name: "Cherrypick PR with jlp-no-clone label skips clone creation",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				Labels: []string{"jlp-no-clone"},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+				},
+			}}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherrypick:          true,
+			cherryPickFromPRNum: 1,
+			options:             JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: The bug [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has the ` + "`jlp-no-clone`" + ` label, skipping clone creation.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`,
+		},
+		{
+			name: "Cherrypick command with jlp-no-clone label skips clone creation",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				Labels: []string{"jlp-no-clone"},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+				},
+			}}},
+			prs: []github.PullRequest{{Number: 2, Body: "This is a manually created cherrypick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			overrideEvent: &event{
+				org: "org", repo: "repo", baseRef: "branch", number: 2, issues: []referencedIssue{{Project: "OCPBUGS", ID: "123", IsBug: true}}, body: "/jira cherrypick OCPBUGS-123", title: "fixed it!", htmlUrl: "https://github.com/org/repo/pull/1", login: "user", cherrypick: true, cherrypickCmd: true, missing: true,
+			},
+			cherrypick: true,
+			missing:    true,
+			options:    JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#2:@user: The bug [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has the ` + "`jlp-no-clone`" + ` label, skipping clone creation.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>/jira cherrypick OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`,
+		},
+		{
 			name: "Cherrypick comment results in cloned bug creation",
 			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
 				Assignee: &jira.User{Name: "testUser"},


### PR DESCRIPTION
When a Jira bug has the `jlp-no-clone` label, skip automatic clone
creation for both automated cherry-picks and /jira cherrypick commands.

Our prodsec issues are automatically generated for every version, cloning them
apparently causes issues with their workflow - this allows opt'ing out of the
jira issue clone for the ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a `jlp-no-clone` label that skips automatic clone creation and notifies users when cloning is bypassed.

* **Bug Fixes**
  * Prevented empty clone identifiers from being recorded during cherrypick operations.

* **Tests**
  * Added tests verifying cloning is skipped and appropriate notifications are posted when the `jlp-no-clone` label is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->