### PR TITLE
feat: enable LOG project and add support for non-bug state transfers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ GO_LD_EXTRAFLAGS=-X github.com/openshift-eng/jira-lifecycle-plugin/vendor/k8s.io
 vulncheck:
 	./hack/govulncheck-wrapper.sh
 .PHONY: vulncheck
+
+.PHONY: test
+test:
+	go test ./...

--- a/cmd/jira-lifecycle-plugin/config.go
+++ b/cmd/jira-lifecycle-plugin/config.go
@@ -175,10 +175,8 @@ func jiraStatesMatch(first, second []JiraBugState) bool {
 		return false
 	}
 
-	firstSet := NewJiraBugStateSet(first)
 	secondSet := NewJiraBugStateSet(second)
-
-	for state := range firstSet {
+	for _, state := range first {
 		if !secondSet.Has(state) {
 			return false
 		}

--- a/cmd/jira-lifecycle-plugin/config.go
+++ b/cmd/jira-lifecycle-plugin/config.go
@@ -122,6 +122,16 @@ type JiraBranchOptions struct {
 	// the FixVersion and AffectsVersion fields of the bug are set to `premerge`.
 	PreMergeStateAfterClose *JiraBugState `json:"premerge_state_after_close,omitempty"`
 
+	// TaskStateAfterValidation is the state to which non-bug issues (Task, Story, etc.) will be moved
+	// after being deemed valid and linked to a PR. If unset, StateAfterValidation is used for all issue types.
+	TaskStateAfterValidation *JiraBugState `json:"task_state_after_validation,omitempty"`
+	// TaskStateAfterMerge is the state to which non-bug issues will be moved after all pull requests
+	// in the external bug tracker have been merged. If unset, StateAfterMerge is used for all issue types.
+	TaskStateAfterMerge *JiraBugState `json:"task_state_after_merge,omitempty"`
+	// TaskStateAfterClose is the state to which non-bug issues will be moved if all pull requests
+	// in the external bug tracker have been closed. If unset, StateAfterClose is used for all issue types.
+	TaskStateAfterClose *JiraBugState `json:"task_state_after_close,omitempty"`
+
 	// AllowedSecurityLevels is a list of the name of jira issue security levels that the jira plugin can
 	// link to in PRs. If an issue has a security level that is not in this list, the jira
 	// plugin will not link the issue to the PR.
@@ -178,35 +188,47 @@ func jiraStatesMatch(first, second []JiraBugState) bool {
 }
 
 func (o JiraBranchOptions) matches(other JiraBranchOptions) bool {
-	validateByDefaultMatch := o.ValidateByDefault == nil && other.ValidateByDefault == nil ||
-		(o.ValidateByDefault != nil && other.ValidateByDefault != nil && *o.ValidateByDefault == *other.ValidateByDefault)
-	isOpenMatch := o.IsOpen == nil && other.IsOpen == nil ||
-		(o.IsOpen != nil && other.IsOpen != nil && *o.IsOpen == *other.IsOpen)
-	targetReleaseMatch := o.TargetVersion == nil && other.TargetVersion == nil ||
-		(o.TargetVersion != nil && other.TargetVersion != nil && *o.TargetVersion == *other.TargetVersion)
-	skipTargetVersionCheckMatch := o.SkipTargetVersionCheck == nil && other.SkipTargetVersionCheck == nil ||
-		(o.SkipTargetVersionCheck != nil && other.SkipTargetVersionCheck != nil && *o.SkipTargetVersionCheck == *other.SkipTargetVersionCheck)
-	bugStatesMatch := o.ValidStates == nil && other.ValidStates == nil ||
-		(o.ValidStates != nil && other.ValidStates != nil && jiraStatesMatch(*o.ValidStates, *other.ValidStates))
-	dependentBugStatesMatch := o.DependentBugStates == nil && other.DependentBugStates == nil ||
-		(o.DependentBugStates != nil && other.DependentBugStates != nil && jiraStatesMatch(*o.DependentBugStates, *other.DependentBugStates))
-	statesAfterValidationMatch := o.StateAfterValidation == nil && other.StateAfterValidation == nil ||
-		(o.StateAfterValidation != nil && other.StateAfterValidation != nil && *o.StateAfterValidation == *other.StateAfterValidation)
-	addExternalLinkMatch := o.AddExternalLink == nil && other.AddExternalLink == nil ||
-		(o.AddExternalLink != nil && other.AddExternalLink != nil && *o.AddExternalLink == *other.AddExternalLink)
-	statesAfterMergeMatch := o.StateAfterMerge == nil && other.StateAfterMerge == nil ||
-		(o.StateAfterMerge != nil && other.StateAfterMerge != nil && *o.StateAfterMerge == *other.StateAfterMerge)
-	preMergestatesAfterMergeMatch := o.PreMergeStateAfterMerge == nil && other.PreMergeStateAfterMerge == nil ||
-		(o.PreMergeStateAfterMerge != nil && other.PreMergeStateAfterMerge != nil && *o.PreMergeStateAfterMerge == *other.PreMergeStateAfterMerge)
-	releaseNotesMatch := o.RequireReleaseNotes == nil && other.RequireReleaseNotes == nil ||
-		(o.RequireReleaseNotes != nil && other.RequireReleaseNotes != nil && *o.RequireReleaseNotes == *other.RequireReleaseNotes)
-	releaseNotesTextMatch := o.ReleaseNotesDefaultText == nil && other.ReleaseNotesDefaultText == nil ||
-		(o.ReleaseNotesDefaultText != nil && other.ReleaseNotesDefaultText != nil && *o.ReleaseNotesDefaultText == *other.ReleaseNotesDefaultText)
-	ignoreCloneLabelsMatch := len(o.IgnoreCloneLabels) == 0 && len(other.IgnoreCloneLabels) == 0 ||
-		(sets.New[string](o.IgnoreCloneLabels...).Equal(sets.New[string](other.IgnoreCloneLabels...)))
-	return validateByDefaultMatch && isOpenMatch && targetReleaseMatch && skipTargetVersionCheckMatch && bugStatesMatch && dependentBugStatesMatch &&
-		statesAfterValidationMatch && addExternalLinkMatch && statesAfterMergeMatch && preMergestatesAfterMergeMatch &&
-		releaseNotesMatch && releaseNotesTextMatch && ignoreCloneLabelsMatch
+	return ptrEqual(o.ValidateByDefault, other.ValidateByDefault) &&
+		ptrEqual(o.IsOpen, other.IsOpen) &&
+		ptrEqual(o.TargetVersion, other.TargetVersion) &&
+		ptrEqual(o.SkipTargetVersionCheck, other.SkipTargetVersionCheck) &&
+		ptrSliceEqual(o.ValidStates, other.ValidStates, jiraStatesMatch) &&
+		ptrSliceEqual(o.DependentBugStates, other.DependentBugStates, jiraStatesMatch) &&
+		ptrEqual(o.StateAfterValidation, other.StateAfterValidation) &&
+		ptrEqual(o.AddExternalLink, other.AddExternalLink) &&
+		ptrEqual(o.StateAfterMerge, other.StateAfterMerge) &&
+		ptrEqual(o.PreMergeStateAfterMerge, other.PreMergeStateAfterMerge) &&
+		ptrEqual(o.RequireReleaseNotes, other.RequireReleaseNotes) &&
+		ptrEqual(o.ReleaseNotesDefaultText, other.ReleaseNotesDefaultText) &&
+		sets.New(o.IgnoreCloneLabels...).Equal(sets.New(other.IgnoreCloneLabels...)) &&
+		ptrEqual(o.TaskStateAfterValidation, other.TaskStateAfterValidation) &&
+		ptrEqual(o.TaskStateAfterMerge, other.TaskStateAfterMerge) &&
+		ptrEqual(o.TaskStateAfterClose, other.TaskStateAfterClose)
+}
+
+// getStateAfterValidation returns the appropriate state transition for validation based on issue type.
+// Bug issues use StateAfterValidation; all other types (Task, Story, etc.) use TaskStateAfterValidation if set.
+func (o JiraBranchOptions) getStateAfterValidation(it IssueType) *JiraBugState {
+	if it == IssueTypeBug || o.TaskStateAfterValidation == nil {
+		return o.StateAfterValidation
+	}
+	return o.TaskStateAfterValidation
+}
+
+// getStateAfterMerge returns the appropriate state transition for merge based on issue type.
+func (o JiraBranchOptions) getStateAfterMerge(it IssueType) *JiraBugState {
+	if it == IssueTypeBug || o.TaskStateAfterMerge == nil {
+		return o.StateAfterMerge
+	}
+	return o.TaskStateAfterMerge
+}
+
+// getStateAfterClose returns the appropriate state transition for close based on issue type.
+func (o JiraBranchOptions) getStateAfterClose(it IssueType) *JiraBugState {
+	if it == IssueTypeBug || o.TaskStateAfterClose == nil {
+		return o.StateAfterClose
+	}
+	return o.TaskStateAfterClose
 }
 
 const JiraOptionsWildcard = `*`
@@ -271,6 +293,15 @@ func ResolveJiraOptions(parent, child JiraBranchOptions) JiraBranchOptions {
 		if parent.PreMergeStateAfterClose != nil {
 			output.PreMergeStateAfterClose = parent.PreMergeStateAfterClose
 		}
+		if parent.TaskStateAfterValidation != nil {
+			output.TaskStateAfterValidation = parent.TaskStateAfterValidation
+		}
+		if parent.TaskStateAfterMerge != nil {
+			output.TaskStateAfterMerge = parent.TaskStateAfterMerge
+		}
+		if parent.TaskStateAfterClose != nil {
+			output.TaskStateAfterClose = parent.TaskStateAfterClose
+		}
 		if parent.AllowedSecurityLevels != nil {
 			output.AllowedSecurityLevels = sets.NewString(output.AllowedSecurityLevels...).Insert(parent.AllowedSecurityLevels...).List()
 		}
@@ -332,6 +363,15 @@ func ResolveJiraOptions(parent, child JiraBranchOptions) JiraBranchOptions {
 	}
 	if child.PreMergeStateAfterClose != nil {
 		output.PreMergeStateAfterClose = child.PreMergeStateAfterClose
+	}
+	if child.TaskStateAfterValidation != nil {
+		output.TaskStateAfterValidation = child.TaskStateAfterValidation
+	}
+	if child.TaskStateAfterMerge != nil {
+		output.TaskStateAfterMerge = child.TaskStateAfterMerge
+	}
+	if child.TaskStateAfterClose != nil {
+		output.TaskStateAfterClose = child.TaskStateAfterClose
 	}
 	if child.AllowedSecurityLevels != nil {
 		output.AllowedSecurityLevels = sets.NewString(output.AllowedSecurityLevels...).Insert(child.AllowedSecurityLevels...).List()
@@ -451,4 +491,24 @@ func (o *PreMergeVerificationOptions) Excluded(org, repo string) bool {
 		return true
 	}
 	return false
+}
+
+func ptrEqual[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func ptrSliceEqual[T any](a, b *[]T, eq func([]T, []T) bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return eq(*a, *b)
 }

--- a/cmd/jira-lifecycle-plugin/config_test.go
+++ b/cmd/jira-lifecycle-plugin/config_test.go
@@ -709,3 +709,82 @@ func TestPreMergeVerificationOptionsExcluded(t *testing.T) {
 		})
 	}
 }
+
+func TestPtrEqual(t *testing.T) {
+	a, b := "hello", "hello"
+	different := "world"
+
+	testCases := []struct {
+		name     string
+		a, b     *string
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "first nil", a: nil, b: &b, expected: false},
+		{name: "second nil", a: &a, b: nil, expected: false},
+		{name: "equal values", a: &a, b: &b, expected: true},
+		{name: "different values", a: &a, b: &different, expected: false},
+		{name: "same pointer", a: &a, b: &a, expected: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := ptrEqual(tc.a, tc.b); actual != tc.expected {
+				t.Errorf("ptrEqual(%v, %v) = %t, want %t", tc.a, tc.b, actual, tc.expected)
+			}
+		})
+	}
+
+	// Verify it works with other comparable types
+	one, two := 1, 2
+	same := 1
+	t.Run("int equal", func(t *testing.T) {
+		if !ptrEqual(&one, &same) {
+			t.Error("expected equal ints to match")
+		}
+	})
+	t.Run("int not equal", func(t *testing.T) {
+		if ptrEqual(&one, &two) {
+			t.Error("expected different ints to not match")
+		}
+	})
+}
+
+func TestPtrSliceEqual(t *testing.T) {
+	s1 := []string{"a", "b"}
+	s2 := []string{"a", "b"}
+	s3 := []string{"c", "d"}
+	empty := []string{}
+
+	eq := func(a, b []string) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	testCases := []struct {
+		name     string
+		a, b     *[]string
+		expected bool
+	}{
+		{name: "both nil", a: nil, b: nil, expected: true},
+		{name: "first nil", a: nil, b: &s1, expected: false},
+		{name: "second nil", a: &s1, b: nil, expected: false},
+		{name: "equal slices", a: &s1, b: &s2, expected: true},
+		{name: "different slices", a: &s1, b: &s3, expected: false},
+		{name: "both empty", a: &empty, b: &empty, expected: true},
+		{name: "empty vs non-empty", a: &empty, b: &s1, expected: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := ptrSliceEqual(tc.a, tc.b, eq); actual != tc.expected {
+				t.Errorf("ptrSliceEqual(%v, %v) = %t, want %t", tc.a, tc.b, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2514,10 +2514,10 @@ func handleClose(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 						response += " All external bug links have been closed."
 						if changeState {
 							response += fmt.Sprintf(" The bug has been moved to the %s state.", PrettyStatus(updatedState.Status, updatedState.Resolution))
-						}
-						jiraComment := &jira.Comment{Body: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", updatedState.Status, e.org, e.repo, e.number), Visibility: PrivateVisibility}
-						if _, err := jc.AddComment(bug.ID, jiraComment); err != nil {
-							response += "\nWarning: Failed to comment on Jira bug with reason for changed state."
+							jiraComment := &jira.Comment{Body: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", updatedState.Status, e.org, e.repo, e.number), Visibility: PrivateVisibility}
+							if _, err := jc.AddComment(bug.ID, jiraComment); err != nil {
+								response += "\nWarning: Failed to comment on Jira bug with reason for changed state."
+							}
 						}
 					}
 				}
@@ -2912,7 +2912,6 @@ func formatTransitionError(err error, endpoint, bugKey string) string {
 	}
 	return formatError(err.Error(), endpoint, bugKey, err)
 }
-
 
 func transitionIssue(jc jiraclient.Client, issue *jira.Issue, targetState *JiraBugState) (bool, error) {
 	if targetState == nil {

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -57,7 +57,7 @@ var (
 	existingBackportMatch    = regexp.MustCompile(`jlp-[^:]+:[^:]+`)
 	cherrypickPRMatch        = regexp.MustCompile(`This is an automated cherry-pick of #([0-9]+)`)
 	jiraIssueReferenceMatch  = regexp.MustCompile(`([[:alnum:]]+)-([[:digit:]]+)`)
-	bugProjects              = sets.New("OCPBUGS", "DFBUGS", "PROJQUAY")
+	bugProjects              = sets.New("OCPBUGS", "DFBUGS", "PROJQUAY", "LOG")
 )
 
 type referencedIssue struct {
@@ -96,6 +96,18 @@ func (jc *jcWithGetUserStruct) GetUser(accountID string) (*jira.User, error) {
 		return nil, jiraclient.HandleJiraError(response, err)
 	}
 	return user, nil
+}
+
+type IssueType string
+
+const IssueTypeBug IssueType = "bug"
+
+// issueType returns the issue type name, defaulting to IssueTypeBug if unavailable.
+func issueType(issue *jira.Issue) IssueType {
+	if issue.Fields != nil && issue.Fields.Type.Name != "" {
+		return IssueType(strings.ToLower(issue.Fields.Type.Name))
+	}
+	return IssueTypeBug
 }
 
 type server struct {
@@ -500,23 +512,13 @@ func handle(jc jcWithGetUser, ghc githubClient, inserter BigQueryInserter, repoO
 					} else {
 						premergeVerified := isPreMergeVerified(issue, prLabels)
 						if premergeVerified && branchOptions.PreMergeStateAfterValidation != nil {
-							if branchOptions.PreMergeStateAfterValidation.Status != "" && (issue.Fields.Status == nil || !strings.EqualFold(issue.Fields.Status.Name, branchOptions.PreMergeStateAfterValidation.Status)) {
-								if err := jc.UpdateStatus(issue.Key, branchOptions.PreMergeStateAfterValidation.Status); err != nil {
-									log.WithError(err).Warn("Unexpected error updating jira issue.")
-									response += formatError(fmt.Sprintf("updating to the %s state", branchOptions.PreMergeStateAfterValidation.Status), jc.JiraURL(), refIssue.Key(), err)
-									continue
-								}
-								premergeUpdated = true
+							changed, err := transitionIssue(jc, issue, branchOptions.PreMergeStateAfterValidation)
+							if err != nil {
+								log.WithError(err).Warn("Unexpected error updating jira issue.")
+								response += formatTransitionError(err, jc.JiraURL(), refIssue.Key())
+								continue
 							}
-							if branchOptions.PreMergeStateAfterValidation.Resolution != "" && (issue.Fields.Resolution == nil || !strings.EqualFold(issue.Fields.Status.Name, branchOptions.PreMergeStateAfterValidation.Resolution)) {
-								updateIssue := jira.Issue{Key: issue.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: branchOptions.PreMergeStateAfterValidation.Resolution}}}
-								if _, err := jc.UpdateIssue(&updateIssue); err != nil {
-									log.WithError(err).Warn("Unexpected error updating jira issue.")
-									response += formatError(fmt.Sprintf("updating to the %s resolution", branchOptions.PreMergeStateAfterMerge.Resolution), jc.JiraURL(), refIssue.Key(), err)
-									continue
-								}
-								premergeUpdated = true
-							}
+							premergeUpdated = changed
 						}
 						// if this is a premerge verified issue, we don't want to run the usual verification on it; just treat it as a reference instead
 						refIssue.IsBug = !premergeVerified
@@ -616,21 +618,14 @@ func handle(jc jcWithGetUser, ghc githubClient, inserter BigQueryInserter, repoO
 					log.Debug("Valid bug found.")
 					response += fmt.Sprintf(`This pull request references `+issueLink+`, which is valid.`, refIssue.Key(), jc.JiraURL(), refIssue.Key())
 					// if configured, move the bug to the new state
-					if branchOptions.StateAfterValidation != nil {
-						if branchOptions.StateAfterValidation.Status != "" && (issue.Fields.Status == nil || !strings.EqualFold(branchOptions.StateAfterValidation.Status, issue.Fields.Status.Name)) {
-							if err := jc.UpdateStatus(issue.ID, branchOptions.StateAfterValidation.Status); err != nil {
-								log.WithError(err).Warn("Unexpected error updating jira issue.")
-								return comment(formatError(fmt.Sprintf("updating to the %s state", branchOptions.StateAfterValidation.Status), jc.JiraURL(), refIssue.Key(), err))
-							}
-							if branchOptions.StateAfterValidation.Resolution != "" && (issue.Fields.Resolution == nil || !strings.EqualFold(branchOptions.StateAfterValidation.Resolution, issue.Fields.Resolution.Name)) {
-								updateIssue := jira.Issue{Key: issue.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: branchOptions.StateAfterValidation.Resolution}}}
-								if _, err := jc.UpdateIssue(&updateIssue); err != nil {
-									log.WithError(err).Warn("Unexpected error updating jira issue.")
-									return comment(formatError(fmt.Sprintf("updating to the %s resolution", branchOptions.StateAfterValidation.Resolution), jc.JiraURL(), refIssue.Key(), err))
-								}
-							}
-							response += fmt.Sprintf(" The bug has been moved to the %s state.", branchOptions.StateAfterValidation)
-						}
+					stateAfterValidation := branchOptions.getStateAfterValidation(issueType(issue))
+					changed, err := transitionIssue(jc, issue, stateAfterValidation)
+					if err != nil {
+						log.WithError(err).Warn("Unexpected error updating jira issue.")
+						return comment(formatTransitionError(err, jc.JiraURL(), refIssue.Key()))
+					}
+					if changed {
+						response += fmt.Sprintf(" The bug has been moved to the %s state.", stateAfterValidation)
 					}
 
 					response += "\n\n<details>"
@@ -1592,18 +1587,8 @@ func validateBug(bug *jira.Issue, dependents []dependent, options JiraBranchOpti
 	if options.ValidStates != nil {
 		var allowed []JiraBugState
 		allowed = append(allowed, *options.ValidStates...)
-		if options.StateAfterValidation != nil {
-			stateAlreadyExists := false
-			for _, state := range allowed {
-				if strings.EqualFold(state.Status, options.StateAfterValidation.Status) && strings.EqualFold(state.Resolution, options.StateAfterValidation.Resolution) {
-					stateAlreadyExists = true
-					break
-				}
-			}
-			if !stateAlreadyExists {
-				allowed = append(allowed, *options.StateAfterValidation)
-			}
-		}
+		allowed = appendUniqueState(allowed, options.StateAfterValidation)
+		allowed = appendUniqueState(allowed, options.TaskStateAfterValidation)
 		var status, resolution string
 		if bug.Fields.Status != nil {
 			status = bug.Fields.Status.Name
@@ -1727,12 +1712,7 @@ func validateBug(bug *jira.Issue, dependents []dependent, options JiraBranchOpti
 }
 
 func validateTargetVersion(issue *jira.Issue, requiredTargetVersion string) error {
-	issueType := ""
-	if issue.Fields != nil {
-		issueType = strings.ToLower(issue.Fields.Type.Name)
-	} else {
-		issueType = "bug"
-	}
+	issueType := issueType(issue)
 	targetVersion, err := helpers.GetIssueTargetVersion(issue)
 	if err != nil {
 		return fmt.Errorf("failed to get target version for %s: %v", issueType, err)
@@ -1767,7 +1747,7 @@ type prParts struct {
 }
 
 func handleMerge(e event, gc githubClient, jc jiraclient.Client, options JiraBranchOptions, verificationOptions PreMergeVerificationOptions, log *logrus.Entry, allRepos sets.Set[string]) error {
-	if options.StateAfterMerge == nil {
+	if options.StateAfterMerge == nil && options.TaskStateAfterMerge == nil {
 		return nil
 	}
 	if e.missing {
@@ -1787,7 +1767,7 @@ func handleMerge(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 		if err != nil || bug == nil {
 			return err
 		}
-		if options.ValidStates != nil || options.StateAfterValidation != nil {
+		if options.ValidStates != nil || options.StateAfterValidation != nil || options.TaskStateAfterValidation != nil {
 			// we should only migrate if we can be fairly certain that the bug
 			// is not in a state that required human intervention to get to.
 			// For instance, if a bug is closed after a PR merges it should not
@@ -1797,12 +1777,10 @@ func handleMerge(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 			if options.ValidStates != nil {
 				allowed = append(allowed, *options.ValidStates...)
 			}
-
-			if options.StateAfterValidation != nil {
-				allowed = append(allowed, *options.StateAfterValidation)
-			}
+			allowed = appendUniqueState(allowed, options.StateAfterValidation)
+			allowed = appendUniqueState(allowed, options.TaskStateAfterValidation)
 			if !bugMatchesStates(bug, allowed) {
-				msg += fmt.Sprintf(issueLink+" is in an unrecognized state (%s) and will not be moved to the %s state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), bug.Fields.Status.Name, options.StateAfterMerge)
+				msg += fmt.Sprintf(issueLink+" is in an unrecognized state (%s) and will not be moved to the %s state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), bug.Fields.Status.Name, options.getStateAfterMerge(issueType(bug)))
 				continue
 			}
 		}
@@ -1904,8 +1882,9 @@ All associated pull requests must be merged or unlinked from the Jira bug in ord
 
 `, strings.Join(statements, "\n"))
 
+		resolvedStateAfterMerge := options.getStateAfterMerge(issueType(bug))
 		outcomeMessage := func(action string) string {
-			return fmt.Sprintf(issueLink+" has %sbeen moved to the %s state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), action, options.StateAfterMerge)
+			return fmt.Sprintf(issueLink+" has %sbeen moved to the %s state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), action, resolvedStateAfterMerge)
 		}
 
 		prLabels, err := gc.GetIssueLabels(e.org, e.repo, e.number)
@@ -1937,7 +1916,7 @@ All associated pull requests must be merged or unlinked from the Jira bug in ord
     :heavy_check_mark:  All associated pull requests have merged.
     :heavy_check_mark:  All associated, merged pull requests were pre-merge verified.
 
-`+issueLink+` has been moved to the %s state and will move to the VERIFIED state when the change is available in an accepted nightly payload. :clock4:`, refIssue.Key(), jc.JiraURL(), refIssue.Key(), refIssue.Key(), jc.JiraURL(), refIssue.Key(), options.StateAfterMerge)
+`+issueLink+` has been moved to the %s state and will move to the VERIFIED state when the change is available in an accepted nightly payload. :clock4:`, refIssue.Key(), jc.JiraURL(), refIssue.Key(), refIssue.Key(), jc.JiraURL(), refIssue.Key(), resolvedStateAfterMerge)
 					}
 
 					if updateMsg := updateMergedBugStatus(jc, bug, options, log); updateMsg != "" {
@@ -1951,7 +1930,7 @@ All associated pull requests must be merged or unlinked from the Jira bug in ord
 			} else if isVerifiedLater(prLabels) {
 				// This logic means that the merged PR has been commit verified-later, and we need to handle it accordingly...
 				outcomeMessage = func(action string) string {
-					return fmt.Sprintf("This pull request has the `verified-later` tag and will need to be manually moved to VERIFIED after testing. "+issueLink+" has %sbeen moved to the `%s` state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), action, options.StateAfterMerge)
+					return fmt.Sprintf("This pull request has the `verified-later` tag and will need to be manually moved to VERIFIED after testing. "+issueLink+" has %sbeen moved to the `%s` state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), action, resolvedStateAfterMerge)
 				}
 				if updateMsg := updateMergedBugStatus(jc, bug, options, log); updateMsg != "" {
 					msg += updateMsg
@@ -1961,22 +1940,10 @@ All associated pull requests must be merged or unlinked from the Jira bug in ord
 				outcomeMessage = func(action string) string {
 					return fmt.Sprintf(issueLink+" has %sbeen moved to the %s state.", refIssue.Key(), jc.JiraURL(), refIssue.Key(), action, options.PreMergeStateAfterMerge)
 				}
-				if options.PreMergeStateAfterMerge != nil {
-					if options.PreMergeStateAfterMerge.Status != "" && (bug.Fields.Status == nil || !strings.EqualFold(bug.Fields.Status.Name, options.PreMergeStateAfterMerge.Status)) {
-						if err := jc.UpdateStatus(bug.Key, options.PreMergeStateAfterMerge.Status); err != nil {
-							log.WithError(err).Warn("Unexpected error updating jira bug.")
-							msg += formatError(fmt.Sprintf("updating to the %s state", options.PreMergeStateAfterMerge.Status), jc.JiraURL(), refIssue.Key(), err)
-							continue
-						}
-					}
-					if options.PreMergeStateAfterMerge.Resolution != "" && (bug.Fields.Resolution == nil || !strings.EqualFold(bug.Fields.Status.Name, options.PreMergeStateAfterMerge.Resolution)) {
-						updatebug := jira.Issue{Key: bug.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.PreMergeStateAfterMerge.Resolution}}}
-						if _, err := jc.UpdateIssue(&updatebug); err != nil {
-							log.WithError(err).Warn("Unexpected error updating jira bug.")
-							msg += formatError(fmt.Sprintf("updating to the %s resolution", options.PreMergeStateAfterMerge.Resolution), jc.JiraURL(), refIssue.Key(), err)
-							continue
-						}
-					}
+				if _, err := transitionIssue(jc, bug, options.PreMergeStateAfterMerge); err != nil {
+					log.WithError(err).Warn("Unexpected error updating jira bug.")
+					msg += formatTransitionError(err, jc.JiraURL(), refIssue.Key())
+					continue
 				}
 			} else {
 				if updateMsg := updateMergedBugStatus(jc, bug, options, log); updateMsg != "" {
@@ -2011,20 +1978,10 @@ All associated pull requests must be merged or unlinked from the Jira bug in ord
 }
 
 func updateMergedBugStatus(jc jiraclient.Client, bug *jira.Issue, options JiraBranchOptions, log *logrus.Entry) string {
-	if options.StateAfterMerge != nil {
-		if options.StateAfterMerge.Status != "" && (bug.Fields.Status == nil || !strings.EqualFold(options.StateAfterMerge.Status, bug.Fields.Status.Name)) {
-			if err := jc.UpdateStatus(bug.Key, options.StateAfterMerge.Status); err != nil {
-				log.WithError(err).Warn("Unexpected error updating jira issue.")
-				return formatError(fmt.Sprintf("updating to the %s state", options.StateAfterMerge.Status), jc.JiraURL(), bug.Key, err)
-			}
-			if options.StateAfterMerge.Resolution != "" && (bug.Fields.Resolution == nil || !strings.EqualFold(options.StateAfterMerge.Resolution, bug.Fields.Resolution.Name)) {
-				updateIssue := jira.Issue{Key: bug.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.StateAfterMerge.Resolution}}}
-				if _, err := jc.UpdateIssue(&updateIssue); err != nil {
-					log.WithError(err).Warn("Unexpected error updating jira issue.")
-					return formatError(fmt.Sprintf("updating to the %s resolution", options.StateAfterMerge.Resolution), jc.JiraURL(), bug.Key, err)
-				}
-			}
-		}
+	stateAfterMerge := options.getStateAfterMerge(issueType(bug))
+	if _, err := transitionIssue(jc, bug, stateAfterMerge); err != nil {
+		log.WithError(err).Warn("Unexpected error updating jira issue.")
+		return formatTransitionError(err, jc.JiraURL(), bug.Key)
 	}
 	return ""
 }
@@ -2515,7 +2472,7 @@ func handleClose(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 				msg += formatError("removing this pull request from the external tracker bugs", jc.JiraURL(), refIssue.Key(), err) + "\n\n"
 				continue
 			}
-			if options.StateAfterClose != nil || options.PreMergeStateAfterClose != nil {
+			if options.StateAfterClose != nil || options.PreMergeStateAfterClose != nil || options.TaskStateAfterClose != nil {
 				issue, err := jc.GetIssue(refIssue.Key())
 				if err != nil {
 					log.WithError(err).Warn("Unexpected error getting Jira issue.")
@@ -2540,44 +2497,25 @@ func handleClose(e event, gc githubClient, jc jiraclient.Client, options JiraBra
 						} else {
 							premergeVerified = isPreMergeVerified(bug, labels)
 						}
-						updatedState := JiraBugState{}
+						targetState := options.getStateAfterClose(issueType(bug))
 						if premergeVerified {
-							updatedState = JiraBugState{Status: options.PreMergeStateAfterClose.Status, Resolution: options.PreMergeStateAfterClose.Resolution}
-							if options.PreMergeStateAfterClose.Status != "" && (bug.Fields.Status == nil || !strings.EqualFold(options.PreMergeStateAfterClose.Status, bug.Fields.Status.Name)) {
-								if err := jc.UpdateStatus(issue.ID, options.PreMergeStateAfterClose.Status); err != nil {
-									log.WithError(err).Warn("Unexpected error updating jira issue.")
-									msg += formatError(fmt.Sprintf("updating to the %s state", options.PreMergeStateAfterClose.Status), jc.JiraURL(), refIssue.Key(), err) + "\n\n"
-									continue
-								}
-								if options.PreMergeStateAfterClose.Resolution != "" && (bug.Fields.Resolution == nil || !strings.EqualFold(options.PreMergeStateAfterClose.Resolution, bug.Fields.Resolution.Name)) {
-									updateIssue := jira.Issue{Key: bug.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.PreMergeStateAfterClose.Resolution}}}
-									if _, err := jc.UpdateIssue(&updateIssue); err != nil {
-										log.WithError(err).Warn("Unexpected error updating jira issue.")
-										msg += formatError(fmt.Sprintf("updating to the %s resolution", options.PreMergeStateAfterClose.Resolution), jc.JiraURL(), refIssue.Key(), err) + "\n\n"
-										continue
-									}
-								}
-							}
-						} else {
-							updatedState = JiraBugState{Status: options.StateAfterClose.Status, Resolution: options.StateAfterClose.Resolution}
-							if options.StateAfterClose.Status != "" && (bug.Fields.Status == nil || !strings.EqualFold(options.StateAfterClose.Status, bug.Fields.Status.Name)) {
-								if err := jc.UpdateStatus(issue.ID, options.StateAfterClose.Status); err != nil {
-									log.WithError(err).Warn("Unexpected error updating jira issue.")
-									msg += formatError(fmt.Sprintf("updating to the %s state", options.StateAfterClose.Status), jc.JiraURL(), refIssue.Key(), err) + "\n\n"
-									continue
-								}
-								if options.StateAfterClose.Resolution != "" && (bug.Fields.Resolution == nil || !strings.EqualFold(options.StateAfterClose.Resolution, bug.Fields.Resolution.Name)) {
-									updateIssue := jira.Issue{Key: bug.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: options.StateAfterClose.Resolution}}}
-									if _, err := jc.UpdateIssue(&updateIssue); err != nil {
-										log.WithError(err).Warn("Unexpected error updating jira issue.")
-										msg += formatError(fmt.Sprintf("updating to the %s resolution", options.StateAfterClose.Resolution), jc.JiraURL(), refIssue.Key(), err) + "\n\n"
-										continue
-									}
-								}
-							}
+							targetState = options.PreMergeStateAfterClose
 						}
-						response += fmt.Sprintf(" All external bug links have been closed. The bug has been moved to the %s state.", PrettyStatus(updatedState.Status, updatedState.Resolution))
-						jiraComment := &jira.Comment{Body: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", options.StateAfterClose.Status, e.org, e.repo, e.number), Visibility: PrivateVisibility}
+						updatedState := JiraBugState{}
+						if targetState != nil {
+							updatedState = *targetState
+						}
+						changeState, err := transitionIssue(jc, bug, targetState)
+						if err != nil {
+							log.WithError(err).Warn("Unexpected error updating jira issue.")
+							msg += formatTransitionError(err, jc.JiraURL(), refIssue.Key()) + "\n\n"
+							continue
+						}
+						response += " All external bug links have been closed."
+						if changeState {
+							response += fmt.Sprintf(" The bug has been moved to the %s state.", PrettyStatus(updatedState.Status, updatedState.Resolution))
+						}
+						jiraComment := &jira.Comment{Body: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", updatedState.Status, e.org, e.repo, e.number), Visibility: PrivateVisibility}
 						if _, err := jc.AddComment(bug.ID, jiraComment); err != nil {
 							response += "\nWarning: Failed to comment on Jira bug with reason for changed state."
 						}
@@ -2937,4 +2875,62 @@ func searchIssuesWithPagination(jc jiraclient.Client, jql string, pageSize int) 
 
 	logrus.Debugf("Pagination complete - retrieved %d total issues across %d pages", len(allIssues), pageNum-1)
 	return allIssues, nil
+}
+
+// appendUniqueState appends state to allowed if it is non-nil and not already present
+func appendUniqueState(allowed []JiraBugState, state *JiraBugState) []JiraBugState {
+	if state == nil {
+		return allowed
+	}
+	for _, s := range allowed {
+		if strings.EqualFold(s.Status, state.Status) && strings.EqualFold(s.Resolution, state.Resolution) {
+			return allowed
+		}
+	}
+	return append(allowed, *state)
+}
+
+// transitionIssue updates the status and/or resolution of a Jira issue to match
+// the target state. It skips fields that are already at the desired value and
+// returns whether any changes were made.
+// transitionError holds context about a failed state transition so callers
+// can pass the action description and underlying error separately to formatError.
+type transitionError struct {
+	action string
+	err    error
+}
+
+func (e *transitionError) Error() string { return fmt.Sprintf("%s: %s", e.action, e.err) }
+func (e *transitionError) Unwrap() error { return e.err }
+
+// formatTransitionError extracts the action and underlying error from a transitionError
+// to pass them separately to formatError, avoiding duplicate error text.
+func formatTransitionError(err error, endpoint, bugKey string) string {
+	var te *transitionError
+	if errors.As(err, &te) {
+		return formatError(te.action, endpoint, bugKey, te.err)
+	}
+	return formatError(err.Error(), endpoint, bugKey, err)
+}
+
+
+func transitionIssue(jc jiraclient.Client, issue *jira.Issue, targetState *JiraBugState) (bool, error) {
+	if targetState == nil {
+		return false, nil
+	}
+	changed := false
+	if targetState.Status != "" && (issue.Fields.Status == nil || !strings.EqualFold(targetState.Status, issue.Fields.Status.Name)) {
+		if err := jc.UpdateStatus(issue.ID, targetState.Status); err != nil {
+			return false, &transitionError{action: fmt.Sprintf("updating to the %s state", targetState.Status), err: err}
+		}
+		changed = true
+	}
+	if targetState.Resolution != "" && (issue.Fields.Resolution == nil || !strings.EqualFold(targetState.Resolution, issue.Fields.Resolution.Name)) {
+		updateIssue := jira.Issue{Key: issue.Key, Fields: &jira.IssueFields{Resolution: &jira.Resolution{Name: targetState.Resolution}}}
+		if _, err := jc.UpdateIssue(&updateIssue); err != nil {
+			return false, &transitionError{action: fmt.Sprintf("updating to the %s resolution", targetState.Resolution), err: err}
+		}
+		changed = true
+	}
+	return changed, nil
 }

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -8112,3 +8112,207 @@ func TestSkipDependentBugOptions(t *testing.T) {
 		t.Errorf("skipDependentBugOptions() must not mutate the original DependentBugTargetVersions")
 	}
 }
+
+func TestAppendUniqueState(t *testing.T) {
+	post := JiraBugState{Status: "POST"}
+	modified := JiraBugState{Status: "MODIFIED"}
+	closedErrata := JiraBugState{Status: "CLOSED", Resolution: "ERRATA"}
+
+	testCases := []struct {
+		name     string
+		allowed  []JiraBugState
+		state    *JiraBugState
+		expected []JiraBugState
+	}{
+		{
+			name:     "nil state is a no-op",
+			allowed:  []JiraBugState{post},
+			state:    nil,
+			expected: []JiraBugState{post},
+		},
+		{
+			name:     "nil state on empty slice",
+			allowed:  nil,
+			state:    nil,
+			expected: nil,
+		},
+		{
+			name:     "appends to empty slice",
+			allowed:  nil,
+			state:    &post,
+			expected: []JiraBugState{post},
+		},
+		{
+			name:     "appends new state",
+			allowed:  []JiraBugState{post},
+			state:    &modified,
+			expected: []JiraBugState{post, modified},
+		},
+		{
+			name:     "skips duplicate",
+			allowed:  []JiraBugState{post, modified},
+			state:    &post,
+			expected: []JiraBugState{post, modified},
+		},
+		{
+			name:     "matches case-insensitively",
+			allowed:  []JiraBugState{{Status: "post"}},
+			state:    &post,
+			expected: []JiraBugState{{Status: "post"}},
+		},
+		{
+			name:     "status and resolution both compared",
+			allowed:  []JiraBugState{{Status: "CLOSED", Resolution: "WONTFIX"}},
+			state:    &closedErrata,
+			expected: []JiraBugState{{Status: "CLOSED", Resolution: "WONTFIX"}, closedErrata},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := appendUniqueState(tc.allowed, tc.state)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestTransitionIssue(t *testing.T) {
+	makeIssue := func(status, resolution string) *jira.Issue {
+		issue := &jira.Issue{
+			ID:     "1",
+			Key:    "TEST-123",
+			Fields: &jira.IssueFields{},
+		}
+		if status != "" {
+			issue.Fields.Status = &jira.Status{Name: status}
+		}
+		if resolution != "" {
+			issue.Fields.Resolution = &jira.Resolution{Name: resolution}
+		}
+		return issue
+	}
+
+	testCases := []struct {
+		name               string
+		issue              *jira.Issue
+		targetState        *JiraBugState
+		expectedChanged    bool
+		expectedErr        bool
+		expectedStatus     string
+		expectedResolution string
+	}{
+		{
+			name:            "nil target state is a no-op",
+			issue:           makeIssue("NEW", ""),
+			targetState:     nil,
+			expectedChanged: false,
+		},
+		{
+			name:            "already in target status",
+			issue:           makeIssue("POST", ""),
+			targetState:     &JiraBugState{Status: "POST"},
+			expectedChanged: false,
+			expectedStatus:  "POST",
+		},
+		{
+			name:            "already in target status case-insensitive",
+			issue:           makeIssue("post", ""),
+			targetState:     &JiraBugState{Status: "POST"},
+			expectedChanged: false,
+			expectedStatus:  "post",
+		},
+		{
+			name:            "transitions status",
+			issue:           makeIssue("NEW", ""),
+			targetState:     &JiraBugState{Status: "POST"},
+			expectedChanged: true,
+			expectedStatus:  "POST",
+		},
+		{
+			name:               "sets resolution",
+			issue:              makeIssue("CLOSED", ""),
+			targetState:        &JiraBugState{Resolution: "ERRATA"},
+			expectedChanged:    true,
+			expectedResolution: "ERRATA",
+		},
+		{
+			name:               "already in target resolution",
+			issue:              makeIssue("CLOSED", "ERRATA"),
+			targetState:        &JiraBugState{Resolution: "ERRATA"},
+			expectedChanged:    false,
+			expectedStatus:     "CLOSED",
+			expectedResolution: "ERRATA",
+		},
+		{
+			name:               "already in target resolution case-insensitive",
+			issue:              makeIssue("CLOSED", "errata"),
+			targetState:        &JiraBugState{Resolution: "ERRATA"},
+			expectedChanged:    false,
+			expectedStatus:     "CLOSED",
+			expectedResolution: "errata",
+		},
+		{
+			name:               "transitions status and resolution together",
+			issue:              makeIssue("NEW", ""),
+			targetState:        &JiraBugState{Status: "CLOSED", Resolution: "ERRATA"},
+			expectedChanged:    true,
+			expectedStatus:     "CLOSED",
+			expectedResolution: "ERRATA",
+		},
+		{
+			name:        "missing transition returns error",
+			issue:       makeIssue("NEW", ""),
+			targetState: &JiraBugState{Status: "NONEXISTENT"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakejira.FakeClient{
+				Issues: []*jira.Issue{tc.issue},
+				Transitions: []jira.Transition{
+					{ID: "1", Name: "POST", To: jira.Status{Name: "POST"}},
+					{ID: "2", Name: "MODIFIED", To: jira.Status{Name: "MODIFIED"}},
+					{ID: "3", Name: "CLOSED", To: jira.Status{Name: "CLOSED"}},
+				},
+			}
+			changed, err := transitionIssue(fc, tc.issue, tc.targetState)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if changed != tc.expectedChanged {
+				t.Errorf("expected changed=%t, got %t", tc.expectedChanged, changed)
+			}
+			retrieved, err := fc.GetIssue(tc.issue.Key)
+			if err != nil {
+				t.Fatalf("failed to get issue: %v", err)
+			}
+			if tc.expectedStatus != "" {
+				actual := ""
+				if retrieved.Fields.Status != nil {
+					actual = retrieved.Fields.Status.Name
+				}
+				if actual != tc.expectedStatus {
+					t.Errorf("expected status %q, got %q", tc.expectedStatus, actual)
+				}
+			}
+			if tc.expectedResolution != "" {
+				actual := ""
+				if retrieved.Fields.Resolution != nil {
+					actual = retrieved.Fields.Resolution.Name
+				}
+				if actual != tc.expectedResolution {
+					t.Errorf("expected resolution %q, got %q", tc.expectedResolution, actual)
+				}
+			}
+		})
+	}
+}

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -2010,7 +2010,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				Comments: &jira.Comments{Comments: []*jira.Comment{{
 					Body: "This is a bug",
 				}, {
-					Body:       "Bug status changed to NEW as previous linked PR https://github.com/org/repo/pull/1 has been closed",
+					Body:       "Bug status changed to NEW2 as previous linked PR https://github.com/org/repo/pull/1 has been closed",
 					Visibility: PrivateVisibility,
 				}}},
 				Unknowns: tcontainer.MarshalMap{

--- a/cmd/jira-lifecycle-plugin/validate.go
+++ b/cmd/jira-lifecycle-plugin/validate.go
@@ -51,29 +51,30 @@ func validateStatuses(c *Config) []error {
 
 func checkBranchStatuses(name string, options JiraBranchOptions) []error {
 	errors := []error{}
-	if options.StateAfterClose != nil && !validStatusSet.Has(options.StateAfterClose.Status) {
-		errors = append(errors, fmt.Errorf("%s has invalid status for `state_after_close`: `%s`", name, options.StateAfterClose.Status))
+	validStateConfig := func(jiraState *JiraBugState, configStr string) {
+		if jiraState != nil && !validStatusSet.Has(jiraState.Status) {
+			errors = append(errors, fmt.Errorf("%s has invalid status for `%s`: `%s`", name, configStr, jiraState.Status))
+		}
 	}
-	if options.StateAfterMerge != nil && !validStatusSet.Has(options.StateAfterMerge.Status) {
-		errors = append(errors, fmt.Errorf("%s has invalid status for `state_after_merge`: `%s`", name, options.StateAfterMerge.Status))
-	}
-	if options.StateAfterValidation != nil && !validStatusSet.Has(options.StateAfterValidation.Status) {
-		errors = append(errors, fmt.Errorf("%s has invalid status for `state_after_validation`: `%s`", name, options.StateAfterValidation.Status))
-	}
-	if options.ValidStates != nil {
-		for _, state := range *options.ValidStates {
-			if !validStatusSet.Has(state.Status) {
-				errors = append(errors, fmt.Errorf("%s has invalid status in `valid_states`: `%s`", name, state.Status))
+	validStateConfig(options.StateAfterClose, "state_after_close")
+	validStateConfig(options.StateAfterMerge, "state_after_merge")
+	validStateConfig(options.StateAfterValidation, "state_after_validation")
+	validStateConfig(options.TaskStateAfterValidation, "task_state_after_validation")
+	validStateConfig(options.TaskStateAfterMerge, "task_state_after_merge")
+	validStateConfig(options.TaskStateAfterClose, "task_state_after_close")
+
+	validateStates := func(states *[]JiraBugState, configStr string) {
+		if states != nil {
+			for _, state := range *states {
+				if !validStatusSet.Has(state.Status) {
+					errors = append(errors, fmt.Errorf("%s has invalid status in `%s`: `%s`", name, configStr, state.Status))
+				}
 			}
 		}
 	}
-	if options.DependentBugStates != nil {
-		for _, state := range *options.DependentBugStates {
-			if !validStatusSet.Has(state.Status) {
-				errors = append(errors, fmt.Errorf("%s has invalid status in `dependent_bug_states`: `%s`", name, state.Status))
-			}
-		}
-	}
+	validateStates(options.ValidStates, "valid_states")
+	validateStates(options.DependentBugStates, "dependent_bug_states")
+
 	return errors
 }
 
@@ -86,4 +87,7 @@ var validStatusSet = sets.NewString(status.Assigned,
 	status.ReleasePending,
 	status.Verified,
 	status.Refinement,
-	status.InProgress)
+	status.InProgress,
+	status.ToDo,
+	status.CodeReview,
+	status.Review)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -12,4 +12,7 @@ const (
 	Closed         = "CLOSED"
 	Refinement     = "REFINEMENT"
 	InProgress     = "IN PROGRESS"
+	ToDo           = "TO DO"
+	CodeReview     = "CODE REVIEW"
+	Review         = "REVIEW"
 )


### PR DESCRIPTION
Changes: 

- Enable LOG as a `bugProjects`
- Introduce state modifications for Jira issues that are not Bugs (a.k.a have different states)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task-specific post-validation/merge/close state options for non-bug issues.
  * Added Jira statuses: TO DO, CODE REVIEW, REVIEW.
  * Expanded bug-project detection to include an additional project key.

* **Improvements**
  * Centralized and standardized issue-state transition flow and messaging; messages now only show actual changes.
  * Validation extended to cover task-specific transition fields and additional status values.

* **Tests**
  * Added unit tests for pointer/slice equality helpers and state-transition behavior.

* **Chores**
  * Added a Makefile test target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->