### PR TITLE
Fix Sprint Field handling

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2261,8 +2261,21 @@ func createCherryPickBug(jc jcWithGetUser, bug *jira.Issue, branch string, optio
 	if releaseNoteType != nil {
 		update.Fields.Unknowns[helpers.ReleaseNoteTypeField] = releaseNoteType
 	}
-	sprintID, err := helpers.GetActiveSprintID(sprintField)
 	errs := []string{}
+	var sprints []jira.Sprint
+	switch v := sprintField.(type) {
+	case []jira.Sprint:
+		sprints = v
+	case nil:
+		// Nil is the expected state when not defined
+	default:
+		// keep flow resilient; cloning can proceed even if sprint parsing fails
+		errs = append(errs, fmt.Sprintf(`
+
+WARNING: Unexpected sprint field type %T on source issue. Please update sprint manually on clone.
+`, sprintField))
+	}
+	sprintID, err := helpers.GetActiveSprintID(sprints)
 	if err != nil {
 		errs = append(errs, fmt.Sprintf(`
 

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/google/go-cmp/cmp"
@@ -105,8 +106,21 @@ func TestHandle(t *testing.T) {
 	updated2 := JiraBugState{Status: "UPDATED2"}
 	modified := JiraBugState{Status: "MODIFIED"}
 	verified := []JiraBugState{{Status: "VERIFIED"}}
-	active1 := "com.atlassian.greenhopper.service.sprint.Sprint@11b54434[id=57955,rapidViewId=14885,state=ACTIVE,name=uShift Sprint 248,startDate=2024-01-15T09:00:00.000Z,endDate=2024-02-05T09:00:00.000Z,completeDate=<null>,activatedDate=2024-01-15T08:17:37.677Z,sequence=57955,goal=,autoStartStop=false,synced=false]"
-	closed1 := "com.atlassian.greenhopper.service.sprint.Sprint@57a3e8ba[id=57484,rapidViewId=14885,state=CLOSED,name=uShift Sprint 247,startDate=2023-12-25T17:07:00.000Z,endDate=2024-01-15T17:07:00.000Z,completeDate=2024-01-15T08:15:40.614Z,activatedDate=2023-12-25T14:11:56.948Z,sequence=57484,goal=,autoStartStop=false,synced=false]"
+	active1 := jira.Sprint{
+		ID:        57955,
+		Name:      "uShift Sprint 248",
+		EndDate:   helpers.TimePtr(time.Date(2024, 2, 5, 9, 0, 0, 0, time.UTC)),
+		StartDate: helpers.TimePtr(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
+		State:     "active",
+	}
+	closed1 := jira.Sprint{
+		ID:           57484,
+		Name:         "uShift Sprint 247",
+		EndDate:      helpers.TimePtr(time.Date(2024, 1, 15, 17, 7, 0, 0, time.UTC)),
+		StartDate:    helpers.TimePtr(time.Date(2023, 12, 25, 17, 7, 0, 0, time.UTC)),
+		CompleteDate: helpers.TimePtr(time.Date(2024, 1, 15, 8, 15, 40, 614, time.UTC)),
+		State:        "closed",
+	}
 	jiraTransitions := []jira.Transition{
 		{
 			ID:   "1",
@@ -2424,7 +2438,7 @@ Instructions for interacting with me using PR comments are available [here](http
 				Unknowns: tcontainer.MarshalMap{
 					helpers.SeverityField:      severityCritical,
 					helpers.TargetVersionField: &v2,
-					helpers.SprintField:        []any{active1, closed1},
+					helpers.SprintField:        []jira.Sprint{active1, closed1},
 				},
 			}}},
 			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -2,10 +2,9 @@ package helpers
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"regexp"
-	"strconv"
+	"strings"
+	"time"
 
 	"github.com/andygrunwald/go-jira"
 )
@@ -155,28 +154,10 @@ func GetIssueReleaseNoteType(issue *jira.Issue) (*CustomField, error) {
 	return obj, err
 }
 
-var activeSprintReg = regexp.MustCompile(",state=ACTIVE,")
-var sprintIDReg = regexp.MustCompile("id=([0-9]+)")
-
-func GetActiveSprintID(sprintField any) (int, error) {
-	if sprintField == nil {
-		return -1, nil
-	}
-	sprintFieldSlice, ok := sprintField.([]any)
-	if !ok {
-		return -1, errors.New("failed to convert sprint field to slice of interfaces")
-	}
-	for _, sprint := range sprintFieldSlice {
-		sprintString := sprint.(string)
-		if activeSprintReg.MatchString(sprintString) {
-			if submatch := sprintIDReg.FindStringSubmatch(sprintString); submatch != nil {
-				sprintID, err := strconv.Atoi(submatch[1])
-				if err != nil {
-					// should be impossible based on the regex
-					return -1, fmt.Errorf("failed to parse sprint ID. Err: %w", err)
-				}
-				return sprintID, nil
-			}
+func GetActiveSprintID(sprints []jira.Sprint) (int, error) {
+	for _, sprint := range sprints {
+		if strings.ToUpper(sprint.State) == "ACTIVE" {
+			return sprint.ID, nil
 		}
 	}
 	return -1, nil
@@ -197,4 +178,8 @@ func GetIssueContributors(issue *jira.Issue) (*[]Contributor, error) {
 		return nil, err
 	}
 	return obj, err
+}
+
+func TimePtr(t time.Time) *time.Time {
+	return &t
 }

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/andygrunwald/go-jira"
 	"github.com/google/go-cmp/cmp"
@@ -9,28 +10,49 @@ import (
 
 func TestGetActiveSprintIDs(t *testing.T) {
 	t.Parallel()
-	active1 := "com.atlassian.greenhopper.service.sprint.Sprint@11b54434[id=57955,rapidViewId=14885,state=ACTIVE,name=uShift Sprint 248,startDate=2024-01-15T09:00:00.000Z,endDate=2024-02-05T09:00:00.000Z,completeDate=<null>,activatedDate=2024-01-15T08:17:37.677Z,sequence=57955,goal=,autoStartStop=false,synced=false]"
-	closed1 := "com.atlassian.greenhopper.service.sprint.Sprint@57a3e8ba[id=57484,rapidViewId=14885,state=CLOSED,name=uShift Sprint 247,startDate=2023-12-25T17:07:00.000Z,endDate=2024-01-15T17:07:00.000Z,completeDate=2024-01-15T08:15:40.614Z,activatedDate=2023-12-25T14:11:56.948Z,sequence=57484,goal=,autoStartStop=false,synced=false]"
-	closed2 := "com.atlassian.greenhopper.service.sprint.Sprint@21c6823a[id=57540,rapidViewId=5254,state=CLOSED,name=SDN Sprint 247,startDate=2023-12-25T08:00:00.000Z,endDate=2024-01-13T08:00:00.000Z,completeDate=2024-01-15T10:54:35.488Z,activatedDate=2024-01-08T11:20:24.310Z,sequence=57540,goal=,autoStartStop=false,synced=false]"
+
+	active1 := jira.Sprint{
+		ID:        57955,
+		Name:      "uShift Sprint 248",
+		EndDate:   TimePtr(time.Date(2024, 2, 5, 9, 0, 0, 0, time.UTC)),
+		StartDate: TimePtr(time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)),
+		State:     "active",
+	}
+	closed1 := jira.Sprint{
+		ID:           57484,
+		Name:         "uShift Sprint 247",
+		EndDate:      TimePtr(time.Date(2024, 1, 15, 17, 7, 0, 0, time.UTC)),
+		StartDate:    TimePtr(time.Date(2023, 12, 25, 17, 7, 0, 0, time.UTC)),
+		CompleteDate: TimePtr(time.Date(2024, 1, 15, 8, 15, 40, 614, time.UTC)),
+		State:        "closed",
+	}
+	closed2 := jira.Sprint{
+		ID:           57484,
+		Name:         "uShift Sprint 247",
+		EndDate:      TimePtr(time.Date(2024, 1, 13, 8, 0, 0, 0, time.UTC)),
+		StartDate:    TimePtr(time.Date(2023, 12, 25, 8, 0, 0, 0, time.UTC)),
+		CompleteDate: TimePtr(time.Date(2024, 1, 15, 10, 54, 35, 488, time.UTC)),
+		State:        "closed",
+	}
 	var testCases = []struct {
 		name     string
-		issue    any
+		sprints  []jira.Sprint
 		expected int
 	}{{
 		name:     "Empty",
 		expected: -1,
 	}, {
 		name:     "One active, one closed",
-		issue:    []any{closed1, active1},
+		sprints:  []jira.Sprint{closed1, active1},
 		expected: 57955,
 	}, {
 		name:     "Two closed",
-		issue:    []any{closed1, closed2},
+		sprints:  []jira.Sprint{closed1, closed2},
 		expected: -1,
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			updates, err := GetActiveSprintID(tc.issue)
+			updates, err := GetActiveSprintID(tc.sprints)
 			if err != nil {
 				t.Errorf("Received error when none were expected: %v", err)
 			}


### PR DESCRIPTION
Nasty little bug that's been plaguing `/cherry-pick` and `/backport` operations against bugs that have `Sprints` defined on them.  This has to have been happening since we switched over to Jira Cloud. 

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sprint detection during bug cherry-picks so active sprint associations are preserved more reliably, reducing missing sprint data cases.
  * Cloning operations now continue gracefully when unexpected sprint formats are encountered, with non-blocking warnings rather than failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->