### PR TITLE
Implement markdown link stripping and enhance Jira comment handling

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -57,8 +57,13 @@ var (
 	existingBackportMatch    = regexp.MustCompile(`jlp-[^:]+:[^:]+`)
 	cherrypickPRMatch        = regexp.MustCompile(`This is an automated cherry-pick of #([0-9]+)`)
 	jiraIssueReferenceMatch  = regexp.MustCompile(`([[:alnum:]]+)-([[:digit:]]+)`)
+	markdownLinkRegex        = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
 	bugProjects              = sets.New("OCPBUGS", "DFBUGS", "PROJQUAY")
 )
+
+func stripMarkdownLinks(s string) string {
+	return markdownLinkRegex.ReplaceAllString(s, "$1")
+}
 
 type referencedIssue struct {
 	Project string
@@ -835,8 +840,11 @@ To reference a jira issue, add 'XYZ-NNN:' to the title of this pull request and 
 				}
 				if lastBotComment != nil {
 					// the comment function prepends the user and appends details (which may be different for different events),
-					// so we can't do an exact match. A `strings.Contains` should be good enough
-					if strings.Contains(lastBotComment.Body, response) {
+					// so we can't do an exact match. A `strings.Contains` should be good enough.
+					// We strip markdown links from both sides because the prow-jira plugin may convert
+					// plain issue keys (e.g. PROJECT-123) into markdown links ([PROJECT-123](url)) in
+					// existing comments, which would cause a false mismatch.
+					if strings.Contains(stripMarkdownLinks(lastBotComment.Body), stripMarkdownLinks(response)) {
 						duplicateComment = true
 					}
 				}

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -875,6 +875,24 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 		},
 		{
+			name:                  "valid jira with linkified previous comment does not comment",
+			replaceReferencedBugs: []referencedIssue{{Project: "JIRA", ID: "123", IsBug: false}},
+			issues:                []jira.Issue{{ID: "1", Key: "JIRA-123", Fields: &jira.IssueFields{Project: jira.Project{Key: "JIRA"}, Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityModerate}}}},
+			prComments: map[int][]github.IssueComment{1: {{Body: `org/repo#1:@user: This pull request references [JIRA-123](https://my-jira.com/browse/JIRA-123) which is a valid jira issue.
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`, User: github.User{Login: fakegithub.Bot}}}},
+			labels:         []string{labels.JiraValidRef},
+			expectedLabels: []string{labels.JiraValidRef},
+		},
+		{
 			name:                  "valid jira with incorrect version removes invalid label, adds valid label,comments",
 			replaceReferencedBugs: []referencedIssue{{Project: "JIRA", ID: "123", IsBug: false}},
 			issues:                []jira.Issue{{ID: "1", Key: "JIRA-123", Fields: &jira.IssueFields{Project: jira.Project{Key: "JIRA"}, Type: jira.IssueType{Name: "Issue"}, Unknowns: tcontainer.MarshalMap{helpers.SeverityField: severityModerate}}}},
@@ -5238,6 +5256,49 @@ func checkComments(client *fakegithub.FakeClient, name string, expectedComments 
 		if expectedComment != actualComment {
 			t.Errorf("%s: got incorrect comment: %v", name, cmp.Diff(expectedComment, actualComment))
 		}
+	}
+}
+
+func TestStripMarkdownLinks(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no links",
+			input:    "This pull request references PROJECT-123 which is a valid jira issue.",
+			expected: "This pull request references PROJECT-123 which is a valid jira issue.",
+		},
+		{
+			name:     "single link",
+			input:    "This pull request references [PROJECT-123](https://my-jira.com/browse/PROJECT-123) which is a valid jira issue.",
+			expected: "This pull request references PROJECT-123 which is a valid jira issue.",
+		},
+		{
+			name:     "multiple links",
+			input:    "See [ABC-1](https://jira/browse/ABC-1) and [ABC-2](https://jira/browse/ABC-2) for details.",
+			expected: "See ABC-1 and ABC-2 for details.",
+		},
+		{
+			name:     "issueLink format",
+			input:    "This pull request references [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123), which is valid.",
+			expected: "This pull request references Jira Issue OCPBUGS-123, which is valid.",
+		},
+		{
+			name:     "mixed links and plain text",
+			input:    "Bug [OCPBUGS-1](https://jira/browse/OCPBUGS-1) depends on OCPBUGS-2 which is not linked.",
+			expected: "Bug OCPBUGS-1 depends on OCPBUGS-2 which is not linked.",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := stripMarkdownLinks(tc.input)
+			if actual != tc.expected {
+				t.Errorf("stripMarkdownLinks(%q):\n  got:  %q\n  want: %q", tc.input, actual, tc.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- Added a function to strip markdown links from strings, improving comment comparison logic.
- Introduced a new test case to validate the stripping of markdown links in various scenarios.
- Updated existing comment handling to account for markdown links, ensuring accurate detection of duplicate comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed duplicate comment detection to properly identify repeated comments when issue keys are formatted as Markdown links, preventing unnecessary duplicate comments from being posted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->