### PR TITLE
Purging more customfields that cause issues when cloning

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2178,6 +2178,10 @@ func createCherryPickBug(jc jiraclient.Client, bug *jira.Issue, branch string, o
 	delete(bugCopy.Fields.Unknowns, helpers.RankField)
 	delete(bugCopy.Fields.Unknowns, helpers.DateOfFirstResponseField)
 	delete(bugCopy.Fields.Unknowns, helpers.TimeInStatusField)
+	delete(bugCopy.Fields.Unknowns, helpers.MeanTimeToAcknowledge)
+	delete(bugCopy.Fields.Unknowns, helpers.MeanTimeToResolution)
+	delete(bugCopy.Fields.Unknowns, helpers.TimeToResolution)
+	delete(bugCopy.Fields.Unknowns, helpers.TimeToFirstResponse)
 	// Attachments cannot be set via the Create Issue API; they must be uploaded separately
 	bugCopy.Fields.Attachments = nil
 	// This is the sprint field; sprints are handled by a custom plugin, and the data given to us via
@@ -2612,7 +2616,7 @@ func handleVerification(e event, ghc githubClient, verificationOptions PreMergeV
 	if ok, err := ghc.IsCollaborator(e.org, e.repo, e.login); !ok {
 		return comment("Jira verification commands are restricted to collaborators for this repo.")
 	} else if err != nil {
-		return comment(fmt.Sprintf("Failed to determine wheter user %s is a collaborator for the %s/%s repo. Please try again.", e.login, e.org, e.repo))
+		return comment(fmt.Sprintf("Failed to determine whether user %s is a collaborator for the %s/%s repo. Please try again.", e.login, e.org, e.repo))
 	}
 	msg := ""
 	prLabels, err := ghc.GetIssueLabels(e.org, e.repo, e.number)

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -21,6 +21,10 @@ const (
 	RankField                = "customfield_10019" // "customfield_10019": "Rank"
 	DateOfFirstResponseField = "customfield_10024" // "customfield_10024": "[CHART] Date of First Response"
 	TimeInStatusField        = "customfield_10025" // "customfield_10025": "[CHART] Time in Status"
+	MeanTimeToAcknowledge    = "customfield_10962" // "customfield_10962": "MTTA" - Mean Time to Acknowledge
+	MeanTimeToResolution     = "customfield_10963" // "customfield_10963": "MTTR" - Mean Time to Resolution
+	TimeToResolution         = "customfield_10323" // "customfield_10323": "Time to resolution"
+	TimeToFirstResponse      = "customfield_10324" // "customfield_10324": "Time to first response"
 )
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal


### PR DESCRIPTION
These fields all seem to be related the JSM (or something) and are not necessary when cloning a new issue.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cherry-pick operations now support removal of additional Jira issue fields.
  * Improved Jira API search with pagination support for larger datasets.

* **Bug Fixes**
  * Corrected error message wording in collaborator verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->