### PR TITLE
Deleting invalid QA Contacts that are no longer valid on clones

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2207,6 +2207,20 @@ func createCherryPickBug(jc jiraclient.Client, bug *jira.Issue, branch string, o
 			bugCopy.Fields.Reporter = nil
 		}
 	}
+	qaContact, err := helpers.GetIssueQaContact(&bugCopy)
+	if err != nil {
+		log.WithError(err).Debug("Failed to get QA contact field")
+		delete(bugCopy.Fields.Unknowns, helpers.QAContactField)
+	} else if qaContact != nil {
+		user, err := jc.GetUser(qaContact.AccountID)
+		if err != nil {
+			log.Debugf("QA contact %s could not be retrieved; removing field: %v", qaContact.AccountID, err)
+			delete(bugCopy.Fields.Unknowns, helpers.QAContactField)
+		} else if !user.Active {
+			log.Debugf("QA contact %s is inactive; removing field", qaContact.AccountID)
+			delete(bugCopy.Fields.Unknowns, helpers.QAContactField)
+		}
+	}
 	clone, err := jc.CloneIssue(&bugCopy)
 	if err != nil {
 		log.WithError(err).Debugf("Failed to clone bug %+v", bug)

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -2432,6 +2432,169 @@ Instructions for interacting with me using PR comments are available [here](http
 			}}},
 		},
 		{
+			name: "Cherrypick PR with inactive QA contact results in cloned bug with QA contact removed",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+					helpers.QAContactField:     &jira.User{AccountID: "inactive-qa-id", Name: "inactiveQA"},
+				},
+			}}},
+			jiraUsers:           []*jira.User{{AccountID: "inactive-qa-id", Name: "inactiveQA", Active: false}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherrypick:          true,
+			cherryPickFromPRNum: 1,
+			options:             JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124). Will retitle bug to link to clone.
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`,
+			expectedIssues: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Assignee:    &jira.User{Name: "testUser"},
+				Status:      &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				IssueLinks: []*jira.IssueLink{&cloneOutward1, &blockInward1},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      map[string]any{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					helpers.TargetVersionField: []any{map[string]any{"name": v1Str}},
+				},
+			}}},
+		},
+		{
+			name: "Cherrypick PR with active QA contact preserves QA contact on clone",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+					helpers.QAContactField:     &jira.User{AccountID: "active-qa-id", Name: "activeQA"},
+				},
+			}}},
+			jiraUsers:           []*jira.User{{AccountID: "active-qa-id", Name: "activeQA", Active: true}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherrypick:          true,
+			cherryPickFromPRNum: 1,
+			options:             JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124). Will retitle bug to link to clone.
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`,
+			expectedIssues: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Assignee:    &jira.User{Name: "testUser"},
+				Status:      &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				IssueLinks: []*jira.IssueLink{&cloneOutward1, &blockInward1},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      map[string]any{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					helpers.TargetVersionField: []any{map[string]any{"name": v1Str}},
+					helpers.QAContactField:     map[string]any{"accountId": "active-qa-id", "avatarUrls": map[string]any{}, "name": "activeQA"},
+				},
+			}}},
+		},
+		{
+			name: "Cherrypick PR with not-found QA contact results in cloned bug with QA contact removed",
+			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{
+				Assignee: &jira.User{Name: "testUser"},
+				Status:   &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      severityCritical,
+					helpers.TargetVersionField: &v2,
+					helpers.QAContactField:     &jira.User{AccountID: "deleted-qa-id", Name: "deletedQA"},
+				},
+			}}},
+			jiraUsers:           []*jira.User{},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.title}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.title}},
+			title:               "[v1] " + base.title,
+			cherrypick:          true,
+			cherryPickFromPRNum: 1,
+			options:             JiraBranchOptions{TargetVersion: &v1Str},
+			expectedComment: `org/repo#1:@user: [Jira Issue OCPBUGS-123](https://my-jira.com/browse/OCPBUGS-123) has been cloned as [Jira Issue OCPBUGS-124](https://my-jira.com/browse/OCPBUGS-124). Will retitle bug to link to clone.
+/retitle [v1] OCPBUGS-124: fixed it!
+
+<details>
+
+In response to [this](https://github.com/org/repo/pull/1):
+
+>This PR fixes OCPBUGS-123
+
+
+Instructions for interacting with me using PR comments are available [here](https://prow.ci.openshift.org/command-help?repo=org%2Frepo).  If you have questions or suggestions related to my behavior, please file an issue against the [openshift-eng/jira-lifecycle-plugin](https://github.com/openshift-eng/jira-lifecycle-plugin/issues/new) repository.
+</details>`,
+			expectedIssues: []*jira.Issue{{ID: "2", Key: "OCPBUGS-124", Fields: &jira.IssueFields{
+				Description: "This is a clone of issue OCPBUGS-123. The following is the description of the original issue: \n---\n",
+				Assignee:    &jira.User{Name: "testUser"},
+				Status:      &jira.Status{Name: "CLOSED"},
+				Comments: &jira.Comments{Comments: []*jira.Comment{{
+					Body: "This is a bug",
+				}}},
+				Project: jira.Project{
+					Name: "OCPBUGS",
+					Key:  "OCPBUGS",
+				},
+				IssueLinks: []*jira.IssueLink{&cloneOutward1, &blockInward1},
+				Unknowns: tcontainer.MarshalMap{
+					helpers.SeverityField:      map[string]any{"Value": `<img alt="" src="/images/icons/priorities/critical.svg" width="16" height="16"> Critical`},
+					helpers.TargetVersionField: []any{map[string]any{"name": v1Str}},
+				},
+			}}},
+		},
+		{
 
 			name: "Cherrypick PR with Sprint field results in cloned bug creation",
 			issues: []jira.Issue{{ID: "1", Key: "OCPBUGS-123", Fields: &jira.IssueFields{


### PR DESCRIPTION
In reference to: https://redhat-internal.slack.com/archives/CNHC2DK2M/p1778160207339589

If the QA Contact is no longer valid, when attempting to cherrypick, we will clear it prior to performing the clone operation.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced QA contact handling during issue cloning. The system now validates whether QA contacts are valid and active before cloning them to new issues. Invalid or inactive QA contact references are automatically removed from cloned issues, preventing potential errors.

* **Tests**
  * Updated test cases for issue cloning scenarios to reflect the new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->