### PR TITLE
Fixing Backporting issue when sprints are defined

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -2270,6 +2270,8 @@ func createCherryPickBug(jc jiraclient.Client, bug *jira.Issue, branch string, o
 	switch v := sprintField.(type) {
 	case []jira.Sprint:
 		sprints = v
+	case []interface{}:
+		sprints = getSprints(sprintField.([]interface{}))
 	case nil:
 		// Nil is the expected state when not defined
 	default:
@@ -2963,4 +2965,15 @@ func searchIssuesWithPagination(jc jiraclient.Client, jql string, pageSize int) 
 
 	logrus.Debugf("Pagination complete - retrieved %d total issues across %d pages", len(allIssues), pageNum-1)
 	return allIssues, nil
+}
+
+func getSprints(raw []interface{}) []jira.Sprint {
+	sprints := make([]jira.Sprint, 0, len(raw))
+	for _, v := range raw {
+		s, ok := v.(jira.Sprint)
+		if ok {
+			sprints = append(sprints, s)
+		}
+	}
+	return sprints
 }


### PR DESCRIPTION
Ref: https://redhat-internal.slack.com/archives/CNHC2DK2M/p1778682396173719

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Improved sprint-field handling during cherry-pick operations to support an additional Jira API response shape, converting and preserving sprint data so cloned issues retain correct sprint activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->