### PR TITLE
Handle /verified commands from PR review comments

### DIFF
--- a/cmd/jira-lifecycle-plugin/main.go
+++ b/cmd/jira-lifecycle-plugin/main.go
@@ -223,6 +223,7 @@ func main() {
 	eventServer := githubeventserver.New(o.githubEventServerOptions, secret.GetTokenGenerator(o.webhookSecretFile), logger)
 	eventServer.RegisterHandleIssueCommentEvent(serv.handleIssueComments)
 	eventServer.RegisterHandlePullRequestEvent(serv.handlePullRequest)
+	eventServer.RegisterReviewEventHandler(serv.handleReviewEvent)
 	eventServer.RegisterHelpProvider(serv.helpProvider, logger)
 
 	health := pjutil.NewHealth()

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -372,6 +372,44 @@ func (s *server) handleIssueComments(l *logrus.Entry, e github.IssueCommentEvent
 	}
 }
 
+func reviewEventToIssueComment(re github.ReviewEvent) github.IssueCommentEvent {
+	return github.IssueCommentEvent{
+		Action: github.IssueCommentActionCreated,
+		Issue: github.Issue{
+			Number:      re.PullRequest.Number,
+			Title:       re.PullRequest.Title,
+			PullRequest: &struct{}{},
+		},
+		Comment: github.IssueComment{
+			Body:    re.Review.Body,
+			User:    re.Review.User,
+			HTMLURL: re.Review.HTMLURL,
+		},
+		Repo: re.Repo,
+	}
+}
+
+func (s *server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
+	if re.Action != github.ReviewActionSubmitted {
+		return
+	}
+	ice := reviewEventToIssueComment(re)
+	cfg := s.config()
+
+	events, errs := digestComment(s.ghc, l, ice)
+	for _, err := range errs {
+		l.Errorf("failed to digest review comment: %v", err)
+	}
+	for _, event := range events {
+		branchOptions := cfg.OptionsForBranch(event.org, event.repo, event.baseRef)
+		repoOptions := cfg.OptionsForRepo(event.org, event.repo)
+		verificationOptions := cfg.OptionsForPreMergeVerification()
+		if err := handle(s.jc, s.ghc, s.bigqueryInserter, repoOptions, branchOptions, verificationOptions, l, *event, s.prowConfigAgent.Config().AllRepos); err != nil {
+			l.Errorf("failed to handle review comment: %v", err)
+		}
+	}
+}
+
 func handle(jc jiraclient.Client, ghc githubClient, inserter BigQueryInserter, repoOptions map[string]JiraBranchOptions, branchOptions JiraBranchOptions, verificationOptions PreMergeVerificationOptions, log *logrus.Entry, e event, allRepos sets.Set[string]) error {
 	comment := e.comment(ghc)
 	if !e.missing {

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -7350,6 +7350,170 @@ Instructions for interacting with me using PR comments are available [here](http
 	}
 }
 
+func TestDigestReviewEvent(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		re               github.ReviewEvent
+		title            string
+		merged           bool
+		expected         []*event
+		expectedComments []string
+		expectedErr      bool
+	}{
+		{
+			name: "edited review action is ignored",
+			re: github.ReviewEvent{
+				Action: github.ReviewActionEdited,
+				PullRequest: github.PullRequest{
+					Number: 1,
+					Title:  "OCPBUGS-123: fix something",
+					Base:   github.PullRequestBranch{Ref: "branch"},
+				},
+				Review: github.Review{
+					Body: "/verified by ci",
+					User: github.User{Login: "user"},
+				},
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
+			},
+		},
+		{
+			name: "dismissed review action is ignored",
+			re: github.ReviewEvent{
+				Action: github.ReviewActionDismissed,
+				PullRequest: github.PullRequest{
+					Number: 1,
+					Title:  "OCPBUGS-123: fix something",
+					Base:   github.PullRequestBranch{Ref: "branch"},
+				},
+				Review: github.Review{
+					Body: "/verified by ci",
+					User: github.User{Login: "user"},
+				},
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
+			},
+		},
+		{
+			name: "submitted review with /verified by is processed",
+			re: github.ReviewEvent{
+				Action: github.ReviewActionSubmitted,
+				PullRequest: github.PullRequest{
+					Number: 1,
+					Title:  "OCPBUGS-123: fix something",
+					Base:   github.PullRequestBranch{Ref: "branch"},
+				},
+				Review: github.Review{
+					Body:    "/verified by ci",
+					User:    github.User{Login: "user"},
+					HTMLURL: "www.com",
+				},
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
+			},
+			expected: []*event{
+				{org: "org", repo: "repo", baseRef: "branch", number: 1, issues: []referencedIssue{{Project: "OCPBUGS", ID: "123", IsBug: true}}, body: "/verified by ci", title: "OCPBUGS-123: fix something", htmlUrl: "www.com", login: "user", verify: []string{"ci"}},
+			},
+		},
+		{
+			name: "submitted review with no commands produces no events",
+			re: github.ReviewEvent{
+				Action: github.ReviewActionSubmitted,
+				PullRequest: github.PullRequest{
+					Number: 1,
+					Title:  "OCPBUGS-123: fix something",
+					Base:   github.PullRequestBranch{Ref: "branch"},
+				},
+				Review: github.Review{
+					Body:    "LGTM, looks good to me!",
+					User:    github.User{Login: "user"},
+					HTMLURL: "www.com",
+				},
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
+			},
+		},
+		{
+			name: "submitted review with /verified among other commands",
+			re: github.ReviewEvent{
+				Action: github.ReviewActionSubmitted,
+				PullRequest: github.PullRequest{
+					Number: 1,
+					Title:  "OCPBUGS-123: fix something",
+					Base:   github.PullRequestBranch{Ref: "branch"},
+				},
+				Review: github.Review{
+					Body:    "/jira refresh\n/verified by ci",
+					User:    github.User{Login: "user"},
+					HTMLURL: "www.com",
+				},
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
+			},
+			expected: []*event{
+				{org: "org", repo: "repo", baseRef: "branch", number: 1, issues: []referencedIssue{{Project: "OCPBUGS", ID: "123", IsBug: true}}, body: "/jira refresh\n/verified by ci", title: "OCPBUGS-123: fix something", htmlUrl: "www.com", login: "user", refresh: true},
+				{org: "org", repo: "repo", baseRef: "branch", number: 1, issues: []referencedIssue{{Project: "OCPBUGS", ID: "123", IsBug: true}}, body: "/jira refresh\n/verified by ci", title: "OCPBUGS-123: fix something", htmlUrl: "www.com", login: "user", verify: []string{"ci"}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := fakegithub.NewFakeClient()
+			client.PullRequests = map[int]*github.PullRequest{
+				1: {Base: github.PullRequestBranch{Ref: "branch"}, Title: testCase.re.PullRequest.Title, Merged: testCase.merged},
+			}
+			fakeClient := fakeGHClient{client}
+
+			var ice *github.IssueCommentEvent
+			if testCase.re.Action == github.ReviewActionSubmitted {
+				synthetic := reviewEventToIssueComment(testCase.re)
+				ice = &synthetic
+			}
+
+			if ice == nil {
+				// non-submitted actions should produce no events
+				if len(testCase.expected) != 0 {
+					t.Errorf("%s: expected no events for non-submitted action but test expects events", testCase.name)
+				}
+				return
+			}
+
+			events, errs := digestComment(fakeClient, logrus.WithField("testCase", testCase.name), *ice)
+			hasErr := false
+			for _, err := range errs {
+				if err != nil {
+					hasErr = true
+					break
+				}
+			}
+			if !hasErr && testCase.expectedErr {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if hasErr && !testCase.expectedErr {
+				t.Errorf("%s: expected no error but got errors: %v", testCase.name, errs)
+			}
+
+			actual, expected := events, testCase.expected
+			if len(actual) != len(expected) || (len(actual) > 0 && !reflect.DeepEqual(actual, expected)) {
+				t.Errorf("%s: did not get correct events: %v", testCase.name, cmp.Diff(actual, expected, allowEventAndDate))
+			}
+
+			checkComments(client, testCase.name, testCase.expectedComments, t)
+		})
+	}
+}
+
 func TestBugKeyFromTitle(t *testing.T) {
 	var testCases = []struct {
 		title                string


### PR DESCRIPTION
## Summary

- Register a `PullRequestReviewEvent` handler so `/verified` (and other jira-lifecycle commands) are picked up when submitted as part of a PR review body, not just as standalone issue comments
- Convert the `ReviewEvent` into a synthetic `IssueCommentEvent` and reuse the existing `digestComment` pipeline, keeping the change minimal and ensuring future command additions automatically work for reviews

Fixes #176

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New `TestDigestReviewEvent` covers:
  - `edited`/`dismissed` review actions are ignored
  - `submitted` review with `/verified by ci` is processed
  - Review body with no recognized commands produces no events
  - Multi-line review body with `/verified` among other commands works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended plugin to process GitHub pull request review events, allowing submitted reviews to trigger commands and integrate seamlessly with existing workflows.

* **Tests**
  * Added comprehensive test coverage for review event handling, including command execution verification and filtering of non-applicable review actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->