### PR TITLE
Update devcontainer and modernize code

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@ build_root_image:
   use_build_cache: true
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-4.23
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay-proxy.ci.openshift.org/openshift/ci:openshift_release_rhel-9-release-golang-1.25-openshift-4.23
+FROM quay-proxy.ci.openshift.org/openshift/ci:openshift_release_rhel-9-release-golang-1.26-openshift-5.0
+# /etc/pki permissions are currently broken; set execute permission on /etc/pki directories to allow traversal
+RUN chmod -R +x /etc/pki/
 # Create non-root user for rootless podman installations
 RUN groupadd --gid 1000 dev && useradd --uid 1000 --gid 1000 -m dev && mkdir /home/dev/go && chown -R dev:dev /home/dev/go
 USER dev
@@ -7,6 +9,9 @@ ENV GOPATH=/home/dev/go GOCACHE=/home/dev/go/cache GOFLAGS='' PATH=/home/dev/go/
 # Install common golang tools
 RUN echo $PATH && go install golang.org/x/vuln/cmd/govulncheck@latest && \
     go install golang.org/x/tools/gopls@latest && \
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && \
     go install github.com/go-delve/delve/cmd/dlv@latest && \
+    go install github.com/mikefarah/yq/v4@latest && \
     go clean -cache -modcache
+
+# golangci-lint recommends pulling the prebuilt binary instead of building from source
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		"--security-opt=label=disable" // this is needed for SELinux enabled systems
 	],
 	"containerUser": "dev",
-	"updateRemoteUserUID": true,
+	"updateRemoteUserUID": false,
 	"containerEnv": {
 		"HOME": "/home/dev"
 	}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 
 .idea/
 .dccache
+# local Claude settings; global Claude gitignore does not work in devcontainer
+.claude/settings.local.json

--- a/cmd/jira-lifecycle-plugin/bigquery.go
+++ b/cmd/jira-lifecycle-plugin/bigquery.go
@@ -55,10 +55,10 @@ func (i *VerificationInfo) Save() (map[string]bigquery.Value, string, error) {
 func (f *fakeBigQueryInserter) Put(ctx context.Context, data any) error {
 	info, ok := data.(VerificationInfo)
 	if !ok {
-		return errors.New("Data is not a VerficationInfo struct")
+		return errors.New("data is not a VerficationInfo struct")
 	}
 	if info.Timestamp.IsZero() {
-		return errors.New("Time is unset")
+		return errors.New("time is unset")
 	}
 	// set time of struct to zero for unit tests
 	info.Timestamp = time.Time{}

--- a/cmd/jira-lifecycle-plugin/config.go
+++ b/cmd/jira-lifecycle-plugin/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// Options for specific orgs. The `*` wildcard will apply to all orgs.
 	Orgs map[string]JiraOrgOptions `json:"orgs,omitempty"`
 	// PreMergeVerification options for Pre-Merge Verification.
-	PreMergeVerification PreMergeVerificationOptions `json:"premerge_verification,omitempty"`
+	PreMergeVerification PreMergeVerificationOptions `json:"premerge_verification"`
 }
 
 // JiraOrgOptions holds options for checking Jira bugs for an org.
@@ -203,7 +203,7 @@ func (o JiraBranchOptions) matches(other JiraBranchOptions) bool {
 	releaseNotesTextMatch := o.ReleaseNotesDefaultText == nil && other.ReleaseNotesDefaultText == nil ||
 		(o.ReleaseNotesDefaultText != nil && other.ReleaseNotesDefaultText != nil && *o.ReleaseNotesDefaultText == *other.ReleaseNotesDefaultText)
 	ignoreCloneLabelsMatch := len(o.IgnoreCloneLabels) == 0 && len(other.IgnoreCloneLabels) == 0 ||
-		(sets.New[string](o.IgnoreCloneLabels...).Equal(sets.New[string](other.IgnoreCloneLabels...)))
+		(sets.New(o.IgnoreCloneLabels...).Equal(sets.New(other.IgnoreCloneLabels...)))
 	return validateByDefaultMatch && isOpenMatch && targetReleaseMatch && skipTargetVersionCheckMatch && bugStatesMatch && dependentBugStatesMatch &&
 		statesAfterValidationMatch && addExternalLinkMatch && statesAfterMergeMatch && preMergestatesAfterMergeMatch &&
 		releaseNotesMatch && releaseNotesTextMatch && ignoreCloneLabelsMatch
@@ -447,8 +447,5 @@ func (b *Config) OptionsForPreMergeVerification() PreMergeVerificationOptions {
 
 // Excluded checks whether the specified repository is excluded from pre-merge validation
 func (o *PreMergeVerificationOptions) Excluded(org, repo string) bool {
-	if slices.Contains(o.ExcludedRepositories, fmt.Sprintf("%s/%s", org, repo)) {
-		return true
-	}
-	return false
+	return slices.Contains(o.ExcludedRepositories, fmt.Sprintf("%s/%s", org, repo))
 }

--- a/cmd/jira-lifecycle-plugin/main.go
+++ b/cmd/jira-lifecycle-plugin/main.go
@@ -101,7 +101,7 @@ func (o *options) Validate() error {
 
 	if o.bigqueryEnable &&
 		(o.bigquerySecretFile == "" || o.bigqueryProjectID == "" || o.bigqueryDatasetID == "") {
-		return errors.New("All BigQuery flags must be set to enable Big Query uploading.")
+		return errors.New("all BigQuery flags must be set to enable Big Query uploading")
 	}
 
 	return nil

--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -426,16 +426,18 @@ func handle(jc jiraclient.Client, ghc githubClient, inserter BigQueryInserter, r
 				if !bugAllowed {
 					// ignore bugs that are in non-allowed security levels for this repo
 					if e.opened || e.refresh {
-						response := fmt.Sprintf(issueLink+" is in a security level that is not in the allowed security levels for this repo.", refIssue.Key(), jc.JiraURL(), refIssue.Key())
+						var response strings.Builder
+						fmt.Fprintf(&response, issueLink+" is in a security level that is not in the allowed security levels for this repo.", refIssue.Key(), jc.JiraURL(), refIssue.Key())
 						if len(branchOptions.AllowedSecurityLevels) > 0 {
-							response += "\nAllowed security levels for this repo are:"
+							response.WriteString("\nAllowed security levels for this repo are:")
 							for _, group := range branchOptions.AllowedSecurityLevels {
-								response += "\n- " + group
+								response.WriteString("\n- ")
+								response.WriteString(group)
 							}
 						} else {
-							response += " There are no allowed security levels configured for this repo."
+							response.WriteString(" There are no allowed security levels configured for this repo.")
 						}
-						return comment(response)
+						return comment(response.String())
 					}
 					return nil
 				}
@@ -463,9 +465,10 @@ func handle(jc jiraclient.Client, ghc githubClient, inserter BigQueryInserter, r
 			log.WithError(err).Warn("Could not list labels on PR")
 		}
 		for _, label := range currentLabels {
-			if label.Name == labels.Verified {
+			switch label.Name {
+			case labels.Verified:
 				_ = removeVerifiedLabel(e, ghc, inserter, log, "modified")
-			} else if label.Name == labels.VerifiedLater {
+			case labels.VerifiedLater:
 				_ = removeVerifiedLaterLabel(e, ghc, inserter, log, "modified")
 			}
 		}
@@ -670,13 +673,13 @@ func handle(jc jiraclient.Client, ghc githubClient, inserter BigQueryInserter, r
 					}
 				} else {
 					log.Debug("Invalid bug found.")
-					var formattedReasons string
+					var formattedReasons strings.Builder
 					for _, reason := range fails {
-						formattedReasons += fmt.Sprintf(" - %s\n", reason)
+						fmt.Fprintf(&formattedReasons, " - %s\n", reason)
 					}
 					response += fmt.Sprintf(`This pull request references `+issueLink+`, which is invalid:
 %s
-Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jira bug are made, or edit the title of this pull request to link to a different bug.`, refIssue.Key(), jc.JiraURL(), refIssue.Key(), formattedReasons)
+Comment <code>/jira refresh</code> to re-evaluate validity if changes to the Jira bug are made, or edit the title of this pull request to link to a different bug.`, refIssue.Key(), jc.JiraURL(), refIssue.Key(), formattedReasons.String())
 				}
 
 				if branchOptions.AddExternalLink != nil && *branchOptions.AddExternalLink {
@@ -1020,7 +1023,7 @@ func replaceStringIfNeeded(text, old, new string) string {
 		return text
 	}
 
-	var result string
+	var result strings.Builder
 
 	// Golangs stdlib has no strings.IndexAll, only funcs to get the first
 	// or last index for a substring. Definitions/condition/assignments are not
@@ -1041,17 +1044,17 @@ func replaceStringIfNeeded(text, old, new string) string {
 
 	startingIdx = 0
 	for _, idx := range allOldIdx {
-		result += text[startingIdx:idx]
+		result.WriteString(text[startingIdx:idx])
 		if idx == 0 || (text[idx-1] != '[' && text[idx-1] != '/') && text[idx-1] != '`' {
-			result += new
+			result.WriteString(new)
 		} else {
-			result += old
+			result.WriteString(old)
 		}
 		startingIdx = idx + len(old)
 	}
-	result += text[startingIdx:]
+	result.WriteString(text[startingIdx:])
 
-	return result
+	return result.String()
 }
 
 func prURLFromCommentURL(url string) string {
@@ -1254,7 +1257,7 @@ func digestComment(gc githubClient, log *logrus.Entry, ice github.IssueCommentEv
 		return events, errs
 	}
 
-	for _, line := range strings.Split(ice.Comment.Body, "\n") {
+	for line := range strings.SplitSeq(ice.Comment.Body, "\n") {
 		event, err := digestLine(gc, log, ice, line)
 		if event != nil {
 			events = append(events, event)
@@ -1449,7 +1452,7 @@ func formatResponseRaw(body, bodyURL, login, reply, orgRepo string) string {
 `
 	// Quote the user's comment by prepending ">" to each line.
 	var quoted []string
-	for _, l := range strings.Split(body, "\n") {
+	for l := range strings.SplitSeq(body, "\n") {
 		quoted = append(quoted, ">"+l)
 	}
 	return formatResponse(login, reply, fmt.Sprintf(format, bodyURL, strings.Join(quoted, "\n")), orgRepo)
@@ -1520,11 +1523,12 @@ func processQuery(query *emailToLoginQuery, email string) string {
 	case 1:
 		return fmt.Sprintf("Requesting review from QA contact:\n/cc @%s", query.Search.Edges[0].Node.User.Login)
 	default:
-		response := fmt.Sprintf("Multiple GitHub users were found matching the public email listed for the QA contact in Jira (%s), skipping review request. List of users with matching email:", email)
+		var response strings.Builder
+		fmt.Fprintf(&response, "Multiple GitHub users were found matching the public email listed for the QA contact in Jira (%s), skipping review request. List of users with matching email:", email)
 		for _, edge := range query.Search.Edges {
-			response += fmt.Sprintf("\n\t- %s", edge.Node.User.Login)
+			fmt.Fprintf(&response, "\n\t- %s", edge.Node.User.Login)
 		}
-		return response
+		return response.String()
 	}
 }
 
@@ -2229,7 +2233,7 @@ func createCherryPickBug(jc jiraclient.Client, bug *jira.Issue, branch string, o
 	releaseNoteType := bugCopy.Fields.Unknowns[helpers.ReleaseNoteTypeField]
 	releaseNoteText := bugCopy.Fields.Unknowns[helpers.ReleaseNoteTextField]
 	if len(options.IgnoreCloneLabels) != 0 {
-		labelsSet := sets.New[string](bugCopy.Fields.Labels...)
+		labelsSet := sets.New(bugCopy.Fields.Labels...)
 		labelsSet.Delete(options.IgnoreCloneLabels...)
 		bugCopy.Fields.Labels = labelsSet.UnsortedList()
 	}
@@ -2308,8 +2312,8 @@ func createCherryPickBug(jc jiraclient.Client, bug *jira.Issue, branch string, o
 	switch v := sprintField.(type) {
 	case []jira.Sprint:
 		sprints = v
-	case []interface{}:
-		sprints = getSprints(sprintField.([]interface{}))
+	case []any:
+		sprints = getSprints(sprintField.([]any))
 	case nil:
 		// Nil is the expected state when not defined
 	default:
@@ -2364,13 +2368,13 @@ func handleBackport(e event, gc githubClient, jc jiraclient.Client, repoOptions 
 	}
 	missingDependencies := sets.New[string]()
 	childBranches := make(map[string][]string)
-	var cherrypickBranches string
+	var cherrypickBranches strings.Builder
 	// sort for deterministic tests
 	existingBranches := append(e.backportBranches, e.baseRef)
 	sort.Strings(existingBranches)
 	existingBranchesSet := sets.New(existingBranches...)
 	for _, branch := range e.backportBranches {
-		cherrypickBranches += fmt.Sprintf("\n/cherrypick %s", branch)
+		fmt.Fprintf(&cherrypickBranches, "\n/cherrypick %s", branch)
 		if _, ok := repoOptions[branch]; !ok {
 			continue
 		}
@@ -2392,13 +2396,15 @@ func handleBackport(e event, gc githubClient, jc jiraclient.Client, repoOptions 
 				branchExists = true
 			}
 			if !branchExists {
-				message := dependentBranches[0]
+				var message strings.Builder
+				message.WriteString(dependentBranches[0])
 				if len(dependentBranches) > 0 {
 					for _, dependentBranch := range dependentBranches[1:] {
-						message += " OR " + dependentBranch
+						message.WriteString(" OR ")
+						message.WriteString(dependentBranch)
 					}
 				}
-				missingDependencies.Insert(message + ", ")
+				missingDependencies.Insert(message.String() + ", ")
 			} else {
 				for _, dependentBranch := range dependentBranches {
 					childBranches[dependentBranch] = append(childBranches[dependentBranch], branch)
@@ -2407,13 +2413,16 @@ func handleBackport(e event, gc githubClient, jc jiraclient.Client, repoOptions 
 		}
 	}
 	if len(missingDependencies) != 0 {
-		message := "Missing required branches for backport chain:\n"
+		var message strings.Builder
+		message.WriteString("Missing required branches for backport chain:\n")
 		errorMsgs := missingDependencies.UnsortedList()
 		sort.Strings(errorMsgs)
 		for _, errorMsg := range errorMsgs {
-			message += "- " + errorMsg + "\n"
+			message.WriteString("- ")
+			message.WriteString(errorMsg)
+			message.WriteString("\n")
 		}
-		return comment(message)
+		return comment(message.String())
 	}
 	createdIssuesMessageLines := []string{}
 	for _, refIssue := range e.issues {
@@ -2449,7 +2458,7 @@ func handleBackport(e event, gc githubClient, jc jiraclient.Client, repoOptions 
 	// make message deterministic for tests
 	sort.Strings(createdIssuesMessageLines)
 	createdIssuesMessage := strings.Join(createdIssuesMessageLines, "\n")
-	return comment(fmt.Sprintf("The following backport issues have been created:\n%s\n\nQueuing cherrypicks to the requested branches to be created after this PR merges:%s", createdIssuesMessage, cherrypickBranches))
+	return comment(fmt.Sprintf("The following backport issues have been created:\n%s\n\nQueuing cherrypicks to the requested branches to be created after this PR merges:%s", createdIssuesMessage, cherrypickBranches.String()))
 }
 
 // createLinkedJiras recursively creates all descendants of the provided parent issue based on the child branches map
@@ -2955,7 +2964,7 @@ func notifyQAContact(jc jiraclient.Client, ghc githubClient, log *logrus.Entry, 
 
 // searchIssuesWithPagination performs a paginated search using Jira API v3
 // It properly handles pagination by following nextPageToken until all results are retrieved
-func searchIssuesWithPagination(jc jiraclient.Client, jql string, pageSize int) ([]jira.Issue, error) {
+func searchIssuesWithPagination(jc jiraclient.Client, jql string, pageSize int) ([]jira.Issue, error) { //nolint:unused
 	var allIssues []jira.Issue
 	var nextPageToken string
 	pageNum := 1
@@ -3005,7 +3014,7 @@ func searchIssuesWithPagination(jc jiraclient.Client, jql string, pageSize int) 
 	return allIssues, nil
 }
 
-func getSprints(raw []interface{}) []jira.Sprint {
+func getSprints(raw []any) []jira.Sprint {
 	sprints := make([]jira.Sprint, 0, len(raw))
 	for _, v := range raw {
 		s, ok := v.(jira.Sprint)


### PR DESCRIPTION
Update golang builder to Go 1.26 and Openshift 5.0. This includes a fix for SSL
not working in the container that occurred with a recent version of this image
and using the prebuilt binary for golangci-lint as recommended in their
documentation. It also sets `updateRemoteUserUID` to false, as it is
unnecessary and can cause problems with rootless podman, which handles the
issue via the `--userns` runArgs that we set earlier in the file.

Also update .gitignore to ignore local claude settings, as the global gitignore
does not work in the devcontainer.

---

Run `go fix ./...` on the repo to modernize and improve the code. This
functionality was added in Go 1.26 and combines multiple fixers/modernizers
such as the `gopls` modernizer we have used before into a single, official
command. As our repos update to Go 1.26, I will also add this as a ci-operator
test.

I also applied some extra fixes from the latest golangci-lint that were missing
before and a couple of fixes recommended by `gopls` that are not yet included
in the upstream analyzers used by `go fix`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to Go 1.26 and OpenShift 5.0.
  * Enhanced development container configuration with updated tooling and improved build efficiency.
  * Updated local configuration exclusions for development environments.

* **Bug Fixes**
  * Fixed permission traversal issues in development container setup.
  * Improved error message consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->