### PR TITLE
hack: fix govulncheck wrapper treating scan failures as success.

### DIFF
--- a/hack/govulncheck-wrapper.sh
+++ b/hack/govulncheck-wrapper.sh
@@ -94,13 +94,43 @@ fi
 
 # Run govulncheck with JSON output
 [[ $VERBOSE -eq 1 ]] && log_info "Running govulncheck..."
-VULN_JSON=$(govulncheck -json ./... 2>&1 || true)
+set +e
+VULN_JSON=$(govulncheck -json ./... 2>&1)
+GOVULNCHECK_EXIT=$?
+set -e
 
-# Extract findings from the JSON stream (newline-delimited JSON objects)
+# With -json, govulncheck exits 0 even when vulnerabilities are reported; a non-zero
+# exit means the scan did not finish (toolchain mismatch, package load errors, etc.).
+# Findings are determined from the JSON stream below, not from GOVULNCHECK_EXIT.
+if [[ $GOVULNCHECK_EXIT -ne 0 ]]; then
+  log_error "govulncheck failed (exit $GOVULNCHECK_EXIT)"
+  echo "$VULN_JSON" >&2
+  exit 1
+fi
+
+# JSON mode may emit partial records before appending plain-text errors.
+if grep -qE '^govulncheck:' <<< "$VULN_JSON"; then
+  log_error "govulncheck reported errors"
+  echo "$VULN_JSON" >&2
+  exit 1
+fi
+
+# govulncheck -json emits a stream of pretty-printed JSON objects (not one value per line).
+if [[ -n "$VULN_JSON" ]]; then
+  if ! jq_stderr=$(echo "$VULN_JSON" | jq -e -n 'inputs' 2>&1 >/dev/null); then
+    log_error "govulncheck output is not valid JSON (govulncheck exit $GOVULNCHECK_EXIT)"
+    log_error "$jq_stderr"
+    log_error "raw govulncheck output:"
+    echo "$VULN_JSON" >&2
+    exit 1
+  fi
+fi
+
+# Extract findings from the JSON stream (one pretty-printed object per value)
 # Each finding has: osv (ID), fixed_version (optional), trace[0].module
 # Only consider vulnerabilities where our code actually calls the vulnerable function
 # (trace length > 1 means there's a call path from our code to the vulnerable function)
-FINDINGS=$(echo "$VULN_JSON" | jq -c 'select(.finding) | select(.finding.trace | length > 1) | {id: .finding.osv, module: .finding.trace[0].module, fixed: .finding.fixed_version}' 2>/dev/null || true)
+FINDINGS=$(echo "$VULN_JSON" | jq -c 'select(.finding) | select(.finding.trace | length > 1) | {id: .finding.osv, module: .finding.trace[0].module, fixed: .finding.fixed_version}')
 
 if [[ -z "$FINDINGS" ]]; then
   log_info "No vulnerabilities found"
@@ -129,7 +159,7 @@ while IFS= read -r vuln; do
 
   # Check if this vulnerability is in the ignore list AND has no fix available
   # If a fix is available, we should flag it even if it's in the ignore list
-  if echo "$IGNORED_LIST" | grep -qF "${VULN_ID}|${MODULE}"; then
+  if grep -qxF "${VULN_ID}|${MODULE}" <<< "$IGNORED_LIST"; then
     if [[ "$FIXED" == "N/A" || "$FIXED" == "null" ]]; then
       ((IGNORED_COUNT++)) || true
       [[ $VERBOSE -eq 1 ]] && log_info "Ignored: $VULN_ID in $MODULE (no fix available)"


### PR DESCRIPTION
The wrapper used `|| true` and treated empty findings as a clean scan, so toolchain mismatches, package load errors, and vuln DB failures passed CI while real scans never ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved vulnerability scan wrapper to capture scanner output and treat unexpected non-zero results as failures with clearer error reporting.
  * Detects and surfaces non-JSON or malformed output from JSON-mode scans so issues are reported promptly.
  * Enhanced ignore-list matching to be more robust and avoid false negatives when filtering findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->