### PR TITLE
New fields preventing backports

### DIFF
--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -34,6 +34,9 @@ var CustomFieldsToDelete = []string{
 	"customfield_10429", // "Subtask count"
 	"customfield_10430", // "Comment count"
 	"customfield_10431", // "Attachment count"
+	"customfield_10978", // "SFDC Cases Counter",
+	"customfield_10979", // "SFDC Cases Links",
+	"customfield_10980", // "SFDC Cases Open",
 }
 
 // GetUnknownField will attempt to get the specified field from the Unknowns struct and unmarshal


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup and cloning operations to properly handle three additional custom fields during system processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->