### PR TITLE
NO-ISSUE:link linkification corrupting longer keys containing shorter ones

### DIFF
--- a/cmd/jira-lifecycle-plugin/server.go
+++ b/cmd/jira-lifecycle-plugin/server.go
@@ -1006,55 +1006,64 @@ func insertLinksIntoComment(body string, issueNames []string, jiraBaseURL string
 }
 
 func insertLinksIntoLine(line string, issueNames []string, jiraBaseURL string) string {
-	for _, issue := range issueNames {
+	sorted := make([]string, len(issueNames))
+	copy(sorted, issueNames)
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i]) > len(sorted[j])
+	})
+	for _, issue := range sorted {
 		replacement := fmt.Sprintf("[%s](%s/browse/%s)", issue, strings.TrimSuffix(jiraBaseURL, "/"), issue)
 		line = replaceStringIfNeeded(line, issue, replacement)
 	}
 	return line
 }
 
-// replaceStringIfNeeded replaces a string if it is not prefixed by:
-// * `[` which we use as heuristic for "Already replaced",
-// * `/` which we use as heuristic for "Part of a link in a previous replacement",
-// * ``` (backtick) which we use as heuristic for "Inline code".
-// If golang would support back-references in regex replacements, this would have been a lot
+// replaceStringIfNeeded replaces occurrences of old with new, skipping any
+// match that is not a standalone reference (e.g. part of a longer identifier,
+// already inside a markdown link, a URL path, or inline code).
 func replaceStringIfNeeded(text, old, new string) string {
 	if old == "" {
 		return text
 	}
 
 	var result strings.Builder
-
-	// Golangs stdlib has no strings.IndexAll, only funcs to get the first
-	// or last index for a substring. Definitions/condition/assignments are not
-	// in the header of the loop because that makes it completely unreadable.
-	var allOldIdx []int
-	var startingIdx int
+	start := 0
 	for {
-		idx := strings.Index(text[startingIdx:], old)
+		idx := strings.Index(text[start:], old)
 		if idx == -1 {
 			break
 		}
-		idx = startingIdx + idx
-		// Since we always look for a non-empty string, we know that idx++
-		// can not be out of bounds
-		allOldIdx = append(allOldIdx, idx)
-		startingIdx = idx + 1
-	}
-
-	startingIdx = 0
-	for _, idx := range allOldIdx {
-		result.WriteString(text[startingIdx:idx])
-		if idx == 0 || (text[idx-1] != '[' && text[idx-1] != '/') && text[idx-1] != '`' {
+		idx += start
+		result.WriteString(text[start:idx])
+		if isStandaloneMatch(text, idx, len(old)) {
 			result.WriteString(new)
 		} else {
 			result.WriteString(old)
 		}
-		startingIdx = idx + len(old)
+		start = idx + len(old)
 	}
-	result.WriteString(text[startingIdx:])
+	result.WriteString(text[start:])
 
 	return result.String()
+}
+
+// isStandaloneMatch returns true when the substring at text[idx:idx+length]
+// appears as an isolated reference — not embedded in a longer word, markdown
+// link, URL, or inline code.
+func isStandaloneMatch(text string, idx, length int) bool {
+	if idx > 0 {
+		prev := text[idx-1]
+		switch {
+		case prev == '[', prev == '/', prev == '`':
+			return false
+		case prev >= 'a' && prev <= 'z', prev >= 'A' && prev <= 'Z', prev >= '0' && prev <= '9':
+			return false
+		}
+	}
+	if end := idx + length; end < len(text) && text[end] >= '0' && text[end] <= '9' {
+		return false
+	}
+	return true
 }
 
 func prURLFromCommentURL(url string) string {

--- a/cmd/jira-lifecycle-plugin/server_test.go
+++ b/cmd/jira-lifecycle-plugin/server_test.go
@@ -5457,6 +5457,68 @@ is very important` + "\n``ABC-123`` and `ABC-123` shouldn't be replaced, as well
 	}
 }
 
+func TestInsertLinksIntoLineMultipleIssues(t *testing.T) {
+	t.Parallel()
+	jiraURL := strings.TrimSuffix(fakejira.FakeJiraUrl, "/")
+	testCases := []struct {
+		name       string
+		line       string
+		issueNames []string
+		expected   string
+	}{
+		{
+			name:       "shorter issue key that is a substring of a longer one does not corrupt it",
+			line:       "XPROJ-1560: fix something",
+			issueNames: []string{"PROJ-1", "XPROJ-1560"},
+			expected:   "[XPROJ-1560](https://my-jira.com/browse/XPROJ-1560): fix something",
+		},
+		{
+			name:       "longer issue key replaced correctly regardless of slice order",
+			line:       "XPROJ-1560: fix something",
+			issueNames: []string{"XPROJ-1560", "PROJ-1"},
+			expected:   "[XPROJ-1560](https://my-jira.com/browse/XPROJ-1560): fix something",
+		},
+		{
+			name:       "both issues replaced when they appear separately in the line",
+			line:       "XPROJ-1560 and PROJ-1 are related",
+			issueNames: []string{"PROJ-1", "XPROJ-1560"},
+			expected:   "[XPROJ-1560](https://my-jira.com/browse/XPROJ-1560) and [PROJ-1](https://my-jira.com/browse/PROJ-1) are related",
+		},
+		{
+			name:       "issue key after hyphen is still replaced",
+			line:       "fix-XPROJ-1560: something",
+			issueNames: []string{"PROJ-1", "XPROJ-1560"},
+			expected:   "fix-[XPROJ-1560](https://my-jira.com/browse/XPROJ-1560): something",
+		},
+		{
+			name:       "issue key in parentheses is replaced",
+			line:       "(XPROJ-1560) and (PROJ-1)",
+			issueNames: []string{"PROJ-1", "XPROJ-1560"},
+			expected:   "([XPROJ-1560](https://my-jira.com/browse/XPROJ-1560)) and ([PROJ-1](https://my-jira.com/browse/PROJ-1))",
+		},
+		{
+			name:       "shorter issue number that is a prefix of a longer one is not replaced",
+			line:       "PROJ-1560: fix",
+			issueNames: []string{"PROJ-1"},
+			expected:   "PROJ-1560: fix",
+		},
+		{
+			name:       "issue key glued to preceding text is not replaced",
+			line:       "v2PROJ-123: fix",
+			issueNames: []string{"PROJ-123"},
+			expected:   "v2PROJ-123: fix",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := insertLinksIntoLine(tc.line, tc.issueNames, jiraURL)
+			if diff := cmp.Diff(actual, tc.expected); diff != "" {
+				t.Errorf("insertLinksIntoLine result differs from expected:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestHelpProvider(t *testing.T) {
 	rawConfig := `disabled_jira_projects:
 - "private-project"


### PR DESCRIPTION
When multiple issue keys are referenced and a shorter key is a substring of a longer one (e.g. PROJ-1 inside XPROJ-1560), the shorter key was replaced first, corrupting the longer key into X[PROJ-1](url)560.

Sort issue names by length (longest first) in insertLinksIntoLine and add word boundary checks in replaceStringIfNeeded via a new isStandaloneMatch helper to skip matches embedded in longer identifiers or followed by additional digits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jira issue keys in comments are now linked more reliably.
  * Prevents accidental linking when an issue key appears inside a longer word or identifier.
  * Improves handling of multiple issue keys in the same line, including overlapping key names and different ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->