### PR TITLE
devcontainer: remove -R from chmod

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay-proxy.ci.openshift.org/openshift/ci:openshift_release_rhel-9-release-golang-1.26-openshift-5.0
 # /etc/pki permissions are currently broken; set execute permission on /etc/pki directories to allow traversal
-RUN chmod -R +x /etc/pki/
+RUN chmod +x /etc/pki/
 # Create non-root user for rootless podman installations
 RUN groupadd --gid 1000 dev && useradd --uid 1000 --gid 1000 -m dev && mkdir /home/dev/go && chown -R dev:dev /home/dev/go
 USER dev


### PR DESCRIPTION
Remove unnecessary -R from the `chmod +x /etc/pki` line. Only `/etc/pki` needs to be made executable to allow traversal; we don't need to apply that to descendant files/directories.